### PR TITLE
feat(cli): adding examples

### DIFF
--- a/src/cli/branch.rs
+++ b/src/cli/branch.rs
@@ -10,7 +10,7 @@ use bauplan::{
     table::{GetTables, Table},
 };
 use tabwriter::TabWriter;
-use yansi::Paint;
+use yansi::Paint as _;
 
 use crate::cli::{Cli, Output, api_err_kind, checkout};
 
@@ -42,7 +42,28 @@ pub(crate) enum BranchCommand {
     Rename(BranchRenameArgs),
 }
 
+fn branch_ls_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# List user's own branches".dim(),
+            "bauplan branch ls".bold(),
+            "# List all branches".dim(),
+            "bauplan branch ls --all-zones".bold(),
+            "# Filter by name".dim(),
+            r#"bauplan branch ls --name "dev""#.bold(),
+            "# Filter by user".dim(),
+            "bauplan branch ls --user username".bold(),
+            "# Limit results".dim(),
+            "bauplan branch ls --limit 5".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = branch_ls_help())]
 pub(crate) struct BranchLsArgs {
     /// Branch name
     pub branch_name: Option<String>,
@@ -60,7 +81,24 @@ pub(crate) struct BranchLsArgs {
     pub limit: Option<usize>,
 }
 
+fn branch_create_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Create branch from active branch".dim(),
+            "bauplan branch create username.dev_branch".bold(),
+            "# Create branch from specific ref".dim(),
+            "bauplan branch create username.new_feature --from-ref main".bold(),
+            "# Create branch without failing if exists".dim(),
+            "bauplan branch create username.my_branch --if-not-exists".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = branch_create_help())]
 pub(crate) struct BranchCreateArgs {
     /// Branch name
     pub branch_name: String,
@@ -72,7 +110,22 @@ pub(crate) struct BranchCreateArgs {
     pub if_not_exists: bool,
 }
 
+fn branch_rm_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Delete a branch".dim(),
+            "bauplan branch rm username.old_branch".bold(),
+            "# Delete without failing if not exists".dim(),
+            "bauplan branch rm username.maybe_branch --if-exists".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = branch_rm_help())]
 pub(crate) struct BranchRmArgs {
     /// Branch name
     pub branch_name: String,
@@ -81,7 +134,22 @@ pub(crate) struct BranchRmArgs {
     pub if_exists: bool,
 }
 
+fn branch_get_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Get branch information".dim(),
+            "bauplan branch get username.dev_branch".bold(),
+            "# Get with namespace filter".dim(),
+            "bauplan branch get username.branch --namespace raw_data".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = branch_get_help())]
 pub(crate) struct BranchGetArgs {
     /// Branch name
     pub branch_name: String,
@@ -90,13 +158,43 @@ pub(crate) struct BranchGetArgs {
     pub namespace: Option<String>,
 }
 
+fn branch_checkout_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "bauplan branch checkout main".bold(),
+            "bauplan branch checkout username.dev_branch".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = branch_checkout_help())]
 pub(crate) struct BranchCheckoutArgs {
     /// Branch name
     pub branch_name: String,
 }
 
+fn branch_diff_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Diff between active branch and another".dim(),
+            "bauplan branch diff username.dev_branch".bold(),
+            "# Diff between two specific branches".dim(),
+            "bauplan branch diff main username.dev_branch".bold(),
+            "# Diff with namespace filter".dim(),
+            "bauplan branch diff username.branch1 username.branch2 --namespace raw_data".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = branch_diff_help())]
 pub(crate) struct BranchDiffArgs {
     /// Branch name a
     pub branch_name_a: String,
@@ -107,7 +205,23 @@ pub(crate) struct BranchDiffArgs {
     pub namespace: Option<String>,
 }
 
+fn branch_merge_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Merge branch into active branch".dim(),
+            "bauplan branch merge username.dev_branch".bold(),
+            "# Merge with custom commit message".dim(),
+            r#"bauplan branch merge username.feature --commit-message "Merge feature updates""#
+                .bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = branch_merge_help())]
 pub(crate) struct BranchMergeArgs {
     /// Branch name
     pub branch_name: String,
@@ -116,7 +230,19 @@ pub(crate) struct BranchMergeArgs {
     pub commit_message: Option<String>,
 }
 
+fn branch_rename_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n",
+            "Examples".bold().underline(),
+            "bauplan branch rename username.old_name username.new_name".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = branch_rename_help())]
 pub(crate) struct BranchRenameArgs {
     /// Branch name
     pub branch_name: String,

--- a/src/cli/checkout.rs
+++ b/src/cli/checkout.rs
@@ -1,9 +1,29 @@
 use anyhow::{Context as _, bail};
 use bauplan::branch::{CreateBranch, GetBranch};
+use yansi::Paint as _;
 
 use crate::cli::{Cli, yaml};
 
+fn checkout_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Checkout existing branch".dim(),
+            "bauplan checkout main".bold(),
+            "# Checkout user branch".dim(),
+            "bauplan checkout username.dev_branch".bold(),
+            "# Create and checkout new branch from main".dim(),
+            "bauplan checkout -b username.new_feature --from-ref main".bold(),
+            "# Create and checkout from active branch".dim(),
+            "bauplan checkout -b username.new_feature".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = checkout_help())]
 pub(crate) struct CheckoutArgs {
     /// Branch name
     pub branch_name: String,

--- a/src/cli/commit.rs
+++ b/src/cli/commit.rs
@@ -16,7 +16,30 @@ pub(crate) enum Format {
     Fuller,
 }
 
+fn commit_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Show recent commits on active branch".dim(),
+            "bauplan commit".bold(),
+            "# Show commits from specific branch".dim(),
+            "bauplan commit main".bold(),
+            "# Show more commits".dim(),
+            "bauplan commit --max-count 20".bold(),
+            "# Show commits by specific author".dim(),
+            "bauplan commit --author-username john_doe".bold(),
+            "# Show commits matching message pattern".dim(),
+            r#"bauplan commit --message "^fix.*" --max-count 5"#.bold(),
+            "# Show commits in oneline format".dim(),
+            "bauplan commit --format oneline".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = commit_help())]
 pub(crate) struct CommitArgs {
     /// Ref or branch name to get commits from [default: active branch]
     pub ref_name: Option<String>,

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -36,7 +36,20 @@ impl std::fmt::Display for ConfigSetting {
     }
 }
 
+fn config_set_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Set configuration value".dim(),
+            "bauplan config set api_key your_key".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = config_set_help())]
 pub(crate) struct ConfigSetArgs {
     /// Setting name
     pub name: ConfigSetting,
@@ -44,7 +57,22 @@ pub(crate) struct ConfigSetArgs {
     pub value: String,
 }
 
+fn config_get_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Get specific configuration".dim(),
+            "bauplan config get api_key".bold(),
+            "# Get all profiles".dim(),
+            "bauplan config get --all".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = config_get_help())]
 pub(crate) struct ConfigGetArgs {
     /// Show all the available profiles
     #[arg(short, long)]

--- a/src/cli/job.rs
+++ b/src/cli/job.rs
@@ -84,7 +84,36 @@ pub(crate) enum JobCommand {
     Stop(JobStopArgs),
 }
 
+fn job_ls_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# List recent jobs for current user".dim(),
+            "bauplan job ls".bold(),
+            "# List more jobs".dim(),
+            "bauplan job ls --max-count 20".bold(),
+            "# List all jobs from all users".dim(),
+            "bauplan job ls --all-users --max-count 50".bold(),
+            "# Filter by status".dim(),
+            "bauplan job ls --status running".bold(),
+            "# Filter by job kind".dim(),
+            "bauplan job ls --kind run --kind query".bold(),
+            "# Filter by specific user".dim(),
+            "bauplan job ls --user username".bold(),
+            "# Filter by date range".dim(),
+            "bauplan job ls --created-after 2024-01-01 --created-before 2024-01-31".bold(),
+            "# Filter by job ID".dim(),
+            "bauplan job ls --id abc123 --id def456".bold(),
+            "# Filter failed jobs".dim(),
+            "bauplan job ls --status fail --max-count 10".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = job_ls_help())]
 pub(crate) struct JobLsArgs {
     /// Show jobs from all users, not just your own
     #[arg(long)]
@@ -115,13 +144,41 @@ pub(crate) struct JobLsArgs {
     pub utc: bool,
 }
 
+fn job_get_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Get job details".dim(),
+            "bauplan job get abc123def456".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = job_get_help())]
 pub(crate) struct JobGetArgs {
     /// Job id
     pub job_id: String,
 }
 
+fn job_logs_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Get job logs".dim(),
+            "bauplan job logs abc123def456".bold(),
+            "# Get all logs including system logs".dim(),
+            "bauplan job logs abc123def456 --all --system".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = job_logs_help())]
 pub(crate) struct JobLogsArgs {
     /// Job id
     pub job_id: String,
@@ -133,7 +190,20 @@ pub(crate) struct JobLogsArgs {
     pub all: bool,
 }
 
+fn job_stop_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Stop a running job".dim(),
+            "bauplan job stop abc123def456".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = job_stop_help())]
 pub(crate) struct JobStopArgs {
     /// Job id
     pub job_id: String,

--- a/src/cli/namespace.rs
+++ b/src/cli/namespace.rs
@@ -2,6 +2,7 @@ use std::io::{Write as _, stdout};
 
 use bauplan::{ApiErrorKind, commit::CommitOptions, namespace::*};
 use tabwriter::TabWriter;
+use yansi::Paint as _;
 
 use crate::cli::{Cli, Output, api_err_kind};
 
@@ -23,7 +24,24 @@ pub(crate) enum NamespaceCommand {
     Rm(NamespaceRmArgs),
 }
 
+fn namespace_ls_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# List namespaces on active branch".dim(),
+            "bauplan namespace ls".bold(),
+            "# List namespaces on specific branch".dim(),
+            "bauplan namespace ls --ref main".bold(),
+            "# Limit results".dim(),
+            "bauplan namespace ls --limit 10".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = namespace_ls_help())]
 pub(crate) struct NamespaceLsArgs {
     /// Filter namespaces by name
     pub namespace: Option<String>,
@@ -35,7 +53,24 @@ pub(crate) struct NamespaceLsArgs {
     pub limit: Option<usize>,
 }
 
+fn namespace_create_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Create namespace on active branch".dim(),
+            "bauplan namespace create raw_data".bold(),
+            "# Create namespace on specific branch".dim(),
+            "bauplan namespace create transformed_data --branch main".bold(),
+            "# Create without failing if exists".dim(),
+            "bauplan namespace create my_namespace --if-not-exists".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = namespace_create_help())]
 pub(crate) struct NamespaceCreateArgs {
     /// Namespace
     pub namespace: String,
@@ -50,7 +85,24 @@ pub(crate) struct NamespaceCreateArgs {
     pub commit_body: Option<String>,
 }
 
+fn namespace_rm_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Delete namespace from active branch".dim(),
+            "bauplan namespace rm old_namespace".bold(),
+            "# Delete from specific branch".dim(),
+            "bauplan namespace rm old_namespace --branch main".bold(),
+            "# Delete without failing if not exists".dim(),
+            "bauplan namespace rm maybe_namespace --if-exists".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = namespace_rm_help())]
 pub(crate) struct NamespaceRmArgs {
     /// Namespace
     pub namespace: String,

--- a/src/cli/parameter.rs
+++ b/src/cli/parameter.rs
@@ -54,14 +54,44 @@ pub(crate) enum ParameterCommand {
     Set(ParameterSetArgs),
 }
 
+fn parameter_ls_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# List parameters in current directory".dim(),
+            "bauplan parameter ls".bold(),
+            "# List parameters in specific project directory".dim(),
+            "bauplan parameter ls --project-dir /path/to/project".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = parameter_ls_help())]
 pub(crate) struct ParameterLsArgs {
     /// Path to the root Bauplan project directory.
     #[arg(short, long)]
     pub project_dir: Option<PathBuf>,
 }
 
+fn parameter_rm_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Remove parameter from current project".dim(),
+            "bauplan parameter rm db_connection".bold(),
+            "# Remove parameter from specific project".dim(),
+            "bauplan parameter rm api_key --project-dir /path/to/project".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = parameter_rm_help())]
 pub(crate) struct ParameterRmArgs {
     /// Name of the parameter to remove
     pub name: String,
@@ -70,7 +100,30 @@ pub(crate) struct ParameterRmArgs {
     pub project_dir: Option<PathBuf>,
 }
 
+fn parameter_set_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Set string parameter".dim(),
+            "bauplan parameter set env production --type str".bold(),
+            "# Set integer parameter".dim(),
+            "bauplan parameter set max_rows 1000 --type int".bold(),
+            "# Set boolean parameter".dim(),
+            "bauplan parameter set debug true --type bool".bold(),
+            "# Set secret parameter".dim(),
+            "bauplan parameter set api_key mysecretkey --type secret --required".bold(),
+            "# Set parameter from file".dim(),
+            "bauplan parameter set config --type str --file config.json".bold(),
+            "# Set parameter with description".dim(),
+            r#"bauplan parameter set db_host localhost --type str --description "Database host""#.bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = parameter_set_help())]
 pub(crate) struct ParameterSetArgs {
     /// Name
     pub name: String,

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -18,7 +18,31 @@ use commanderpb::runner_event::Event as RunnerEvent;
 use futures::{Stream, TryStreamExt};
 use tabwriter::TabWriter;
 
+fn query_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        use yansi::Paint as _;
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Run query inline".dim(),
+            r#"bauplan query "SELECT * FROM raw_data.customers LIMIT 10""#.bold(),
+            "# Run query from file".dim(),
+            "bauplan query --file query.sql".bold(),
+            "# Run query with no row limit".dim(),
+            r#"bauplan query --all-rows "SELECT COUNT(*) FROM raw_data.orders""#.bold(),
+            "# Run query on specific branch".dim(),
+            r#"bauplan query --ref main "SELECT * FROM my_table""#.bold(),
+            "# Run query in specific namespace".dim(),
+            r#"bauplan query --namespace raw_data "SELECT * FROM customers LIMIT 5""#.bold(),
+            "# Run query with full output (no truncation)".dim(),
+            r#"bauplan query --no-trunc "SELECT * FROM wide_table""#.bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = query_help())]
 pub(crate) struct QueryArgs {
     /// Sql
     pub sql: Option<String>,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -22,7 +22,7 @@ use rsa::RsaPublicKey;
 use serde::Serialize;
 use tabwriter::TabWriter;
 use tracing::{debug, error, info};
-use yansi::Paint;
+use yansi::Paint as _;
 
 use crate::cli::{
     Cli, KeyValue, OnOff, Priority, format_grpc_status,
@@ -51,7 +51,28 @@ impl Display for Preview {
     }
 }
 
+fn run_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Run pipeline in current directory".dim(),
+            "bauplan run".bold(),
+            "# Dry run without materializing models".dim(),
+            "bauplan run --dry-run".bold(),
+            "# Run with strict mode and preview".dim(),
+            "bauplan run --strict --preview head".bold(),
+            "# Run on specific branch with parameters".dim(),
+            "bauplan run --ref main --param env=prod".bold(),
+            "# Run in background".dim(),
+            "bauplan run --detach".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = run_help())]
 pub(crate) struct RunArgs {
     /// Path to the root Bauplan project directory.
     #[arg(short, long)]

--- a/src/cli/table.rs
+++ b/src/cli/table.rs
@@ -15,7 +15,7 @@ use commanderpb::runner_event::Event as RunnerEvent;
 use indicatif::ProgressBar;
 use tabwriter::TabWriter;
 use tracing::info;
-use yansi::Paint;
+use yansi::Paint as _;
 
 use crate::cli::{
     Cli, KeyValue, Output, Priority, api_err_kind, format_grpc_status,
@@ -54,7 +54,26 @@ pub(crate) enum TableCommand {
     Revert(TableRevertArgs),
 }
 
+fn table_ls_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# List tables on active branch".dim(),
+            "bauplan table ls".bold(),
+            "# List tables in specific namespace".dim(),
+            "bauplan table ls --namespace raw_data".bold(),
+            "# List tables from specific branch".dim(),
+            "bauplan table ls --ref main".bold(),
+            "# Limit results".dim(),
+            "bauplan table ls --limit 20".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = table_ls_help())]
 pub(crate) struct TableLsArgs {
     /// Filter tables by name (exact match or regex)
     #[arg(long)]
@@ -70,7 +89,24 @@ pub(crate) struct TableLsArgs {
     pub limit: Option<usize>,
 }
 
+fn table_get_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Get table info from active branch".dim(),
+            "bauplan table get customers".bold(),
+            "# Get table info from specific branch".dim(),
+            "bauplan table get customers --ref main".bold(),
+            "# Get table info with namespace prefix".dim(),
+            "bauplan table get raw_data.customers".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = table_get_help())]
 pub(crate) struct TableGetArgs {
     /// Table name
     pub table_name: String,
@@ -79,7 +115,24 @@ pub(crate) struct TableGetArgs {
     pub r#ref: Option<String>,
 }
 
+fn table_rm_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Delete table from active branch".dim(),
+            "bauplan table rm old_table".bold(),
+            "# Delete from specific branch".dim(),
+            "bauplan table rm old_table --branch main".bold(),
+            "# Delete without failing if not exists".dim(),
+            "bauplan table rm maybe_table --if-exists".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = table_rm_help())]
 pub(crate) struct TableRmArgs {
     /// Table name
     pub table_name: String,
@@ -94,7 +147,26 @@ pub(crate) struct TableRmArgs {
     pub commit_body: Option<String>,
 }
 
+fn table_create_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Create table from S3 data".dim(),
+            "bauplan table create --name customers --search-uri s3://mybucket/customers/*.parquet --namespace raw_data".bold(),
+            "# Create table with partitioning".dim(),
+            "bauplan table create --name orders --search-uri s3://mybucket/orders/*.parquet --partitioned-by date_column".bold(),
+            "# Create table on specific branch".dim(),
+            "bauplan table create --name products --search-uri s3://mybucket/products/*.parquet --branch main".bold(),
+            "# Replace existing table".dim(),
+            "bauplan table create --name customers --search-uri s3://mybucket/customers/*.parquet --replace".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = table_create_help())]
 pub(crate) struct TableCreateArgs {
     /// Name of the table to create
     pub table_name: String,
@@ -121,7 +193,22 @@ pub(crate) struct TableCreateArgs {
     pub priority: Option<Priority>,
 }
 
+fn table_create_plan_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Create plan and save to file".dim(),
+            "bauplan table create-plan --name customers --search-uri s3://mybucket/customers/*.parquet --save-plan plan.json".bold(),
+            "# Create plan without saving".dim(),
+            "bauplan table create-plan --name products --search-uri s3://mybucket/products/*.parquet".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = table_create_plan_help())]
 pub(crate) struct TableCreatePlanArgs {
     /// Name of the table to create
     pub table_name: String,
@@ -148,7 +235,20 @@ pub(crate) struct TableCreatePlanArgs {
     pub arg: Vec<KeyValue>,
 }
 
+fn table_create_plan_apply_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Apply previously created plan".dim(),
+            "bauplan table create-plan-apply --plan plan.json".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = table_create_plan_apply_help())]
 pub(crate) struct TableCreatePlanApplyArgs {
     /// Path to a plan YAML file; reads from stdin if not provided
     #[arg(long)]
@@ -161,7 +261,26 @@ pub(crate) struct TableCreatePlanApplyArgs {
     pub priority: Option<Priority>,
 }
 
+fn table_create_external_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Create external table from Iceberg metadata".dim(),
+            "bauplan table create-external --name events --metadata-json-uri s3://bucket/metadata.json --namespace raw_data".bold(),
+            "# Create external table from parquet files".dim(),
+            r#"bauplan table create-external --name events --search-pattern "s3://bucket/data/*.parquet" --namespace raw_data"#.bold(),
+            "# Create external table with multiple search patterns".dim(),
+            r#"bauplan table create-external --name events --search-pattern "s3://bucket/2024/*.parquet" --search-pattern "s3://bucket/2025/*.parquet" --namespace raw_data"#.bold(),
+            "# Create and overwrite existing table".dim(),
+            r#"bauplan table create-external --name events --search-pattern "s3://bucket/data/*.parquet" --overwrite"#.bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = table_create_external_help())]
 pub(crate) struct TableCreateExternalArgs {
     /// Name of the external table to create
     pub table_name: String,
@@ -191,7 +310,26 @@ pub(crate) struct TableCreateExternalArgs {
     pub priority: Option<Priority>,
 }
 
+fn table_import_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Import data to existing table".dim(),
+            "bauplan table import --name customers --search-uri s3://bucket/customers/new_data/*.parquet".bold(),
+            "# Import with continue on error flag".dim(),
+            "bauplan table import --name events --search-uri s3://bucket/events/*.parquet --continue-on-error".bold(),
+            "# Import in best-effort mode (ignore new columns)".dim(),
+            "bauplan table import --name products --search-uri s3://bucket/products/*.parquet --best-effort".bold(),
+            "# Import in background".dim(),
+            "bauplan table import --name logs --search-uri s3://bucket/logs/*.parquet --detach".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = table_import_help())]
 pub(crate) struct TableImportArgs {
     /// Name of table where data will be imported into
     pub table_name: String,
@@ -224,7 +362,26 @@ pub(crate) struct TableImportArgs {
     pub priority: Option<Priority>,
 }
 
+fn table_revert_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Revert table from another branch".dim(),
+            "bauplan table revert customers --source-ref main".bold(),
+            "# Revert table to specific branch".dim(),
+            "bauplan table revert customers --source-ref main --into-branch username.dev_branch".bold(),
+            "# Revert and replace if exists".dim(),
+            "bauplan table revert customers --source-ref v1.0 --replace".bold(),
+            "# Revert with commit message".dim(),
+            r#"bauplan table revert customers --source-ref main --commit-body "Reverted due to data issue""#.bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = table_revert_help())]
 pub(crate) struct TableRevertArgs {
     /// Table name
     pub table_name: String,

--- a/src/cli/tag.rs
+++ b/src/cli/tag.rs
@@ -2,6 +2,7 @@ use std::io::{Write as _, stdout};
 
 use bauplan::{ApiErrorKind, tag::*};
 use tabwriter::TabWriter;
+use yansi::Paint as _;
 
 use crate::cli::{Cli, Output, api_err_kind};
 
@@ -25,7 +26,24 @@ pub(crate) enum TagCommand {
     Rename(TagRenameArgs),
 }
 
+fn tag_ls_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# List all tags".dim(),
+            "bauplan tag ls".bold(),
+            "# Filter by name pattern".dim(),
+            r#"bauplan tag ls --name "v.*""#.bold(),
+            "# Limit results".dim(),
+            "bauplan tag ls --limit 10".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = tag_ls_help())]
 pub(crate) struct TagLsArgs {
     /// Filter by name (can be a regex)
     #[arg(long)]
@@ -35,7 +53,24 @@ pub(crate) struct TagLsArgs {
     pub limit: Option<usize>,
 }
 
+fn tag_create_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Create tag from active branch".dim(),
+            "bauplan tag create v1.0".bold(),
+            "# Create tag from specific ref".dim(),
+            "bauplan tag create v1.0 --from-ref main".bold(),
+            "# Create without failing if exists".dim(),
+            "bauplan tag create v1.0 --if-not-exists".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = tag_create_help())]
 pub(crate) struct TagCreateArgs {
     /// Tag name
     pub tag_name: String,
@@ -47,7 +82,22 @@ pub(crate) struct TagCreateArgs {
     pub if_not_exists: bool,
 }
 
+fn tag_rm_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n  {}\n\n  {}\n  {}\n",
+            "Examples".bold().underline(),
+            "# Delete a tag".dim(),
+            "bauplan tag rm v1.0".bold(),
+            "# Delete without failing if not exists".dim(),
+            "bauplan tag rm v1.0 --if-exists".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = tag_rm_help())]
 pub(crate) struct TagRmArgs {
     /// Tag name
     pub tag_name: String,
@@ -56,7 +106,19 @@ pub(crate) struct TagRmArgs {
     pub if_exists: bool,
 }
 
+fn tag_rename_help() -> &'static str {
+    static HELP: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        format!(
+            "{}\n\n  {}\n",
+            "Examples".bold().underline(),
+            "bauplan tag rename v1.0 v1.0-stable".bold(),
+        )
+    });
+    HELP.as_str()
+}
+
 #[derive(Debug, clap::Args)]
+#[command(after_long_help = tag_rename_help())]
 pub(crate) struct TagRenameArgs {
     /// Tag name
     pub tag_name: String,


### PR DESCRIPTION
Adding examples in "after_long_help" clause to be parsed by the script in the /docs

Examples are sourced from a notion doc Ciro created: https://www.notion.so/bauplanlabs/CLI-reference-2ed9c5097c738013ae05cfb411406510

This is used to generate the cli reference page.
(will add the docs PR with the CLI stuff here later)

UPD, styling:
<img width="343" height="243" alt="Screenshot 2026-02-24 at 5 02 23 PM" src="https://github.com/user-attachments/assets/8d43c2ec-ddf2-4131-98ff-ddb328f15bfa" />

