### PR TITLE
build: publish wheels when releasing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,114 @@
+name: Build and publish
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.1.2)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }}/${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: blacksmith-16vcpu-ubuntu-2404
+            os: linux
+            arch: amd64
+          - runner: blacksmith-16vcpu-ubuntu-2404-arm
+            os: linux
+            arch: arm64
+          - runner: macos-latest
+            os: macos
+            arch: arm64
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: jdx/mise-action@v3
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+            ~/.local/share/uv/
+            ~/Library/Caches/uv/
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('Cargo.lock') }}
+
+      - name: Install Python versions
+        run: uv python install 3.10 3.11 3.12 3.13 3.14
+
+      - name: Build CLI binary
+        run: |
+          cargo build --release --bin bauplan
+          rm -f python/data/scripts/.gitkeep python/data/scripts/.gitignore
+          cp target/release/bauplan python/data/scripts/
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          args: >-
+            --release --out dist
+            -i python3.10 python3.11 python3.12 python3.13 python3.14
+          docker-options: -v ~/.cargo:/root/.cargo
+          before-script-linux: |
+            ARCH=$(uname -m | sed 's/aarch64/aarch_64/')
+            curl -sL "https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-${ARCH}.zip" -o /tmp/protoc.zip
+            unzip -qj /tmp/protoc.zip bin/protoc -d /tmp
+            export PATH="/tmp:$PATH"
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v5
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.arch }}
+          path: dist
+
+      - name: Create CLI tarball
+        run: |
+          mkdir -p "${RUNNER_TEMP}/${{ inputs.tag }}"
+          cp target/release/bauplan README.md CHANGELOG.md LICENSE* \
+            "${RUNNER_TEMP}/${{ inputs.tag }}"
+          tar -C "${RUNNER_TEMP}" --numeric-owner \
+            -cvzf "bauplan-${{ inputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz" "${{ inputs.tag }}"
+
+      - name: Upload CLI tarball
+        uses: actions/upload-artifact@v5
+        with:
+          name: cli-tarball-${{ matrix.os }}-${{ matrix.arch }}
+          path: "bauplan-${{ inputs.tag }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz"
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: build
+    environment: release
+    steps:
+      - uses: actions/checkout@v6
+      - uses: jdx/mise-action@v3
+      - name: Download artifacts
+        uses: actions/download-artifact@v6
+
+      - name: Publish wheels to PyPI
+        run: uv publish 'wheels-*/*'
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Upload CLI tarballs to GitHub release
+        run: gh release upload "${{ inputs.tag }}" cli-tarball-*/*.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -6,11 +6,14 @@ on:
       - main
 
 jobs:
-  # Release unpublished packages.
+  # Tag and create a GitHub release for unpublished versions.
   release-plz-release:
     name: Release-plz release
     runs-on: blacksmith-16vcpu-ubuntu-2404
     if: ${{ github.repository_owner == 'BauplanLabs' }}
+    outputs:
+      releases_created: ${{ steps.release-plz.outputs.releases_created }}
+      tag: ${{ steps.release-plz.outputs.releases_created == 'true' && fromJSON(steps.release-plz.outputs.releases)[0].tag || '' }}
     permissions:
       contents: write
     steps:
@@ -24,30 +27,22 @@ jobs:
         id: release-plz
         uses: release-plz/action@v0.5
         with:
-          # Note that we don't currently publish any crates to crates.io,
-          # so this just tags the current commit. If we set `publish = true` in
-          # Cargo.toml, this will also release the crate.
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # We do this here instead of in a separate workflow because it's not
-      # trivial for bot workflows to trigger other workflows (you need a PAT).
-      - name: cargo build
-        if: ${{ steps.release-plz.outputs.releases_created == 'true' }}
-        run: mise x -- cargo build --release
-      - name: create release tarball
-        if: ${{ steps.release-plz.outputs.releases_created == 'true' }}
-        run: |-
-          VERSION=${{ fromJSON(steps.release-plz.outputs.releases)[0].tag }}
-          mkdir "${RUNNER_TEMP}/${VERSION}"
-          cp -r target/release/bauplan README.md CHANGELOG.md LICENSE* \
-            "${RUNNER_TEMP}/${VERSION}"
-          tar -C "${RUNNER_TEMP}" --numeric-owner \
-            -cvzf "bauplan-${VERSION}-linux-amd64.tar.gz" "$VERSION"
-          gh release upload "$VERSION" "bauplan-${VERSION}-linux-amd64.tar.gz"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Build wheels and a tarball with the CLI, and publish them to PyPI and the
+  # GitHub release respectively.
+  publish:
+    name: Publish release artifacts
+    needs: release-plz-release
+    if: ${{ needs.release-plz-release.outputs.releases_created == 'true' }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish.yaml
+    with:
+      tag: ${{ needs.release-plz-release.outputs.tag }}
+    secrets: inherit
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-cargo-
 
       - run: mise x -- just test
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ python-source = "python"
 module-name = "bauplan._internal"
 bindings = "pyo3"
 features = ["pyo3/extension-module", "python"]
+data = "python/data"
 use_base_python = true
 
 [tool.ty.src]

--- a/python/data/scripts/.gitignore
+++ b/python/data/scripts/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!.gitkeep

--- a/python/data/scripts/.gitkeep
+++ b/python/data/scripts/.gitkeep
@@ -1,0 +1,1 @@
+This directory needs to be present because maturin expects to add it as a data direction in the wheel. This file is removed (and replaced with the built CLI) when the wheel is actually built.


### PR DESCRIPTION
This publishes the wheels to PyPi whenever release-plz makes a release. We do it in the same workflow because bot workflows can't trigger other bot workflows.