### PR TITLE
docs: fix typos and incorrect references across codebase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ tree-sitter-python = "0.25"
 yansi = "1.0.1"
 
 # TODO: we're temporarily pulling in a PR that includes docstrings in the built
-# dylib and updates pyo3-introspection to pull the back out when generating pyi
+# dylib and updates pyo3-introspection to pull them back out when generating pyi
 # stubs.
 # https://github.com/PyO3/pyo3/pull/5782
 [patch.crates-io]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ exclude = ["tests/fixtures"]
 [tool.uv]
 cache-keys = [
     { file = "pyproject.toml" },
-    { file = "rust/Cargo.toml" },
+    { file = "Cargo.toml" },
     { file = "src/**/*.rs" },
 ]
 

--- a/python/bauplan/_decorators.py
+++ b/python/bauplan/_decorators.py
@@ -79,7 +79,7 @@ def expectation(
 
     An expectation is a function from one (or more) dataframe-like object(s) to a boolean: it
     is commonly used to perform data validation and data quality checks when running a pipeline.
-    Expectations takes as input the table(s) they are validating and return a boolean indicating
+    Expectations take as input the table(s) they are validating and return a boolean indicating
     whether the expectation is met or not. A Python expectation needs a Python environment to run,
     which is defined using the `python` decorator, e.g.:
 

--- a/python/bauplan/_internal/__init__.pyi
+++ b/python/bauplan/_internal/__init__.pyi
@@ -27,7 +27,7 @@ class Client:
     client = bauplan.Client()
 
     # query the table and return result set as an arrow Table
-    my_table = client.query('SELECT avg(Age) AS average_age FROM bauplan.titanic limit 1', ref='main')
+    my_table = client.query('SELECT avg(age) AS average_age FROM bauplan.titanic limit 1', ref='main')
 
     # efficiently cast the table to a pandas DataFrame
     df = my_table.to_pandas()
@@ -49,10 +49,10 @@ class Client:
     client = bauplan.Client()
     # >> client now authenticates with api_key value "mykey", because api key > profile
 
-    # specify authentication directly - this supercedes BAUPLAN_API_KEY in the environment
+    # specify authentication directly - this supersedes BAUPLAN_API_KEY in the environment
     client = bauplan.Client(api_key='MY_KEY')
 
-    # specify a profile from ~/.bauplan/config.yml - this supercedes BAUPLAN_PROFILE in the environment
+    # specify a profile from ~/.bauplan/config.yml - this supersedes BAUPLAN_PROFILE in the environment
     client = bauplan.Client(profile='default')
     ```
 
@@ -62,18 +62,18 @@ class Client:
         - 400: `bauplan.exceptions.InvalidDataError`
         - 401: `bauplan.exceptions.UnauthorizedError`
         - 403: `bauplan.exceptions.ForbiddenError`
-        - 404: `bauplan.exceptions.ResourceNotFoundError` e.g .ID doesn't match any records
+        - 404: `bauplan.exceptions.ResourceNotFoundError` e.g. ID doesn't match any records
         - 404: `bauplan.exceptions.ApiRouteError` e.g. the given route doesn't exist
         - 405: `bauplan.exceptions.ApiMethodError` e.g. POST on a route with only GET defined
         - 409: `bauplan.exceptions.UpdateConflictError` e.g. creating a record with a name that already exists
         - 429: `bauplan.exceptions.TooManyRequestsError`
 
-    Run/Query/Scan/Import operations raise a subclass of `bauplan.exceptions.BauplanError` that represents, and also return a `bauplan.state.RunState` object containing details and logs:
-        - `bauplan.exceptions.JobError` e.g. something went wrong in a run/query/import/scan; includes error details
+    Run/Query/Scan/Import operations raise a subclass of `bauplan.exceptions.BauplanError` that represents the error, and also return a `bauplan.state.RunState` object containing details and logs:
+        - `bauplan.exceptions.BauplanJobError` e.g. something went wrong in a run/query/import/scan; includes error details
 
     Run/import operations also return a state object that includes a `job_status` and other details.
     There are two ways to check status for run/import operations:
-        1. try/except `bauplan.exceptions.JobError`
+        1. try/except `bauplan.exceptions.BauplanJobError`
         2. check the `state.job_status` attribute
 
     ## Examples
@@ -93,11 +93,11 @@ class Client:
     def __new__(cls, /, profile: str |None = None, api_key: str |None = None, client_timeout: int |None = None, config_file_path: str |None = None) -> Client: ...
     def apply_table_creation_plan(self, /, plan: "TableCreatePlanState | str", *, args: "dict[str, str] | None" = None, priority: "int | None" = None, client_timeout: "int | None" = None) -> "TableCreatePlanApplyState":
         """
-        Apply a plan for creating a table. It is done automaticaly during th
+        Apply a plan for creating a table. It is done automatically during the
         table plan creation if no schema conflicts exist. Otherwise, if schema
         conflicts exist, then this function is used to apply them after the
-        schema conflicts are resolved. Most common schema conflict is a two
-        parquet files with the same column name but different datatype
+        schema conflicts are resolved. The most common schema conflict is two
+        parquet files with the same column name but different datatypes.
 
         Parameters:
             plan: The plan to apply.
@@ -115,7 +115,7 @@ class Client:
         EXPERIMENTAL: Cancel a job by ID.
 
         Parameters:
-            id: A job ID
+            job_id: A job ID
         """
     def create_branch(self, /, branch: "str | Branch", from_ref: "str | Ref", *, if_not_exists: "bool" = False) -> "Branch":
         """
@@ -267,9 +267,9 @@ class Client:
         """
         Create a table from an S3 location.
 
-        This operation will attempt to create a table based of schemas of N
+        This operation will attempt to create a table based on schemas of N
         parquet files found by a given search uri. This is a two step operation using
-        `plan_table_creation ` and  `apply_table_creation_plan`.
+        `plan_table_creation` and `apply_table_creation_plan`.
 
         ```python notest
         import bauplan
@@ -285,7 +285,7 @@ class Client:
         Parameters:
             table: The table which will be created.
             search_uri: The location of the files to scan for schema.
-            branch: The branch name in which to create the table in.
+            branch: The branch name in which to create the table.
             namespace: Optional argument specifying the namespace. If not specified, it will be inferred based on table location or the default.
             partitioned_by: Optional argument specifying the table partitioning.
             replace: Replace the table if it already exists.
@@ -860,10 +860,10 @@ class Client:
         ```
 
         Parameters:
-            table: Previously created table in into which data will be imported.
-            search_uri: Uri which to scan for files to import.
+            table: Previously created table into which data will be imported.
+            search_uri: URI to scan for files to import.
             branch: Branch in which to import the table.
-            namespace: Namespace of the table. If not specified, namespace will be infered from table name or default settings.
+            namespace: Namespace of the table. If not specified, namespace will be inferred from table name or default settings.
             continue_on_error: Do not fail the import even if 1 data import fails.
             import_duplicate_files: Ignore prevention of importing s3 files that were already imported.
             best_effort: Don't fail if schema of table does not match.
@@ -933,9 +933,9 @@ class Client:
         """
         Create a table import plan from an S3 location.
 
-        This operation will attempt to create a table based of schemas of N
+        This operation will attempt to create a table based on schemas of N
         parquet files found by a given search uri. A YAML file containing the
-        schema and plan is returns and if there are no conflicts, it is
+        schema and plan is returned and if there are no conflicts, it is
         automatically applied.
 
         ```python notest
@@ -956,7 +956,7 @@ class Client:
         Parameters:
             table: The table which will be created.
             search_uri: The location of the files to scan for schema.
-            branch: The branch name in which to create the table in.
+            branch: The branch name in which to create the table.
             namespace: Optional argument specifying the namespace. If not specified, it will be inferred based on table location or the default.
             partitioned_by: Optional argument specifying the table partitioning.
             replace: Replace the table if it already exists.

--- a/python/bauplan/standard_expectations.py
+++ b/python/bauplan/standard_expectations.py
@@ -1,5 +1,5 @@
 """
-This module contains standard expectations that can be used to test data artifact in a
+This module contains standard expectations that can be used to test data artifacts in a
 Bauplan pipeline. Using these expectations instead of hand-made ones will make your
 pipeline easier to maintain, and significantly faster and more memory-efficient.
 
@@ -16,7 +16,7 @@ import pyarrow.compute as pc
 def _calculate_string_concatenation(table: pa.Table, columns: list, separator: str = '') -> Any:
     """
     Given a pyarrow table and a list of column names, concatenate the columns into a new column.
-    The caller of the function can then used the column to compare it with an existing column or add it.
+    The caller of the function can then use the column to compare it with an existing column or add it.
 
     The function does attempt type conversion to string if a column is not of type pa.string().
 

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -37,7 +37,7 @@ pub(crate) struct QueryArgs {
     /// Limit number of returned rows. (use --all-rows to disable this)
     #[arg(long, default_value = "10")]
     pub max_rows: Option<u64>,
-    /// Do not limit returned rows. Supercedes --max-rows
+    /// Do not limit returned rows. Supersedes --max-rows
     #[arg(long)]
     pub all_rows: bool,
     /// Do not truncate output

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -71,7 +71,7 @@ pub(crate) struct RunArgs {
     /// Exit upon encountering runtime warnings (e.g., invalid column output)
     #[arg(long)]
     pub strict: Option<OnOff>,
-    /// Run the dag as a transaction. Will create a temporary branch where models are materialized. Once all models succeed, it will be merged to branch in which this run is happenning in
+    /// Run the dag as a transaction. Will create a temporary branch where models are materialized. Once all models succeed, it will be merged to the branch in which this run is happening
     #[arg(short, long)]
     pub transaction: Option<OnOff>,
     /// Dry run the job without materializing any models.
@@ -145,7 +145,7 @@ pub(crate) fn job_request_common(
 /// Runs a job and manages spinners for it. This handles the following common
 /// behavior:
 ///  - Cancelling a job on a cancel signal or a request timeout
-///  - Monitoring job logs until a JobCompletion event is recieved.
+///  - Monitoring job logs until a JobCompletion event is received.
 ///
 /// `thing` influences the format of the spinner message ("Running {thing}...").
 ///

--- a/src/cli/table.rs
+++ b/src/cli/table.rs
@@ -40,15 +40,15 @@ pub(crate) enum TableCommand {
     /// Drop a table from the data catalog (does not free up storage)
     #[clap(alias = "delete", alias = "drop")]
     Rm(TableRmArgs),
-    /// create a new table
+    /// Create a new table
     Create(TableCreateArgs),
-    /// create a plan for a new table
+    /// Create a plan for a new table
     CreatePlan(TableCreatePlanArgs),
-    /// apply a table create plan manually
+    /// Apply a table create plan manually
     CreatePlanApply(TableCreatePlanApplyArgs),
-    /// Create an external read-only Iceberg table from existing data with any copies
+    /// Create an external read-only Iceberg table from existing data without any copies
     CreateExternal(TableCreateExternalArgs),
-    /// import data to an existing table. Use `bauplan table create` to create
+    /// Import data to an existing table. Use `bauplan table create` to create the table first
     Import(TableImportArgs),
     /// Revert a table to a previous state from a source ref
     Revert(TableRevertArgs),
@@ -89,7 +89,7 @@ pub(crate) struct TableRmArgs {
     /// Do not fail if the table does not exist
     #[arg(long)]
     pub if_exists: bool,
-    /// Optinal commit body to append to the commit message
+    /// Optional commit body to append to the commit message
     #[arg(long)]
     pub commit_body: Option<String>,
 }
@@ -207,7 +207,7 @@ pub(crate) struct TableImportArgs {
     /// Don't fail the command even if 1/N files fails to import
     #[arg(long)]
     pub continue_on_error: bool,
-    /// Force importing of files without checking what was already imported. likely result in duplicate rows being imported
+    /// Force importing of files without checking what was already imported. This will likely result in duplicate rows being imported
     #[arg(long)]
     pub import_duplicate_files: bool,
     /// Set to ignore new columns. if an import file  has column aa, bb, and parquet has col aa, bb, cc, columns aa and bb will be imported

--- a/src/proto/bpln_proto/commander/service/v2/common.proto
+++ b/src/proto/bpln_proto/commander/service/v2/common.proto
@@ -56,7 +56,7 @@ message PlannerLog {
 }
 
 // TODO: consider renaming this to something generic, as this seems to be specific to `bauplan run`
-// but is used else where
+// but is used elsewhere
 message TriggerRunOpts {
   bool cache = 1;
 }

--- a/src/proto/bpln_proto/commander/service/v2/runner_events.proto
+++ b/src/proto/bpln_proto/commander/service/v2/runner_events.proto
@@ -52,12 +52,12 @@ message JobFailure {
     // orchestration of a job
     ERROR_CODE_UNSPECIFIED = 0;
 
-    // Sent when the failure is due a user error. It can be used to know when
+    // Sent when the failure is due to a user error. It can be used to know when
     // to provide more information to the user.
     ERROR_CODE_RUNTIME_TASK_USER_ERROR = 1;
 
     // This is specific to a runtime task failure. If it is unspecified, it
-    // means something wrong happend on scheduler/executor side and should be
+    // means something wrong happened on scheduler/executor side and should be
     // treated as different than a runtime task failure
     ERROR_CODE_RUNTIME_INTERNAL_ERROR = 2;
   }

--- a/src/python.rs
+++ b/src/python.rs
@@ -57,7 +57,7 @@ impl ClientError {
 /// client = bauplan.Client()
 ///
 /// # query the table and return result set as an arrow Table
-/// my_table = client.query('SELECT avg(age) AS average_age FROM bauplan.titanic limit 1', ref='main')
+/// my_table = client.query('SELECT avg(Age) AS average_age FROM bauplan.titanic limit 1', ref='main')
 ///
 /// # efficiently cast the table to a pandas DataFrame
 /// df = my_table.to_pandas()
@@ -79,10 +79,10 @@ impl ClientError {
 /// client = bauplan.Client()
 /// # >> client now authenticates with api_key value "mykey", because api key > profile
 ///
-/// # specify authentication directly - this supercedes BAUPLAN_API_KEY in the environment
+/// # specify authentication directly - this supersedes BAUPLAN_API_KEY in the environment
 /// client = bauplan.Client(api_key='MY_KEY')
 ///
-/// # specify a profile from ~/.bauplan/config.yml - this supercedes BAUPLAN_PROFILE in the environment
+/// # specify a profile from ~/.bauplan/config.yml - this supersedes BAUPLAN_PROFILE in the environment
 /// client = bauplan.Client(profile='default')
 /// ```
 ///
@@ -92,18 +92,18 @@ impl ClientError {
 ///     - 400: `bauplan.exceptions.InvalidDataError`
 ///     - 401: `bauplan.exceptions.UnauthorizedError`
 ///     - 403: `bauplan.exceptions.ForbiddenError`
-///     - 404: `bauplan.exceptions.ResourceNotFoundError` e.g .ID doesn't match any records
+///     - 404: `bauplan.exceptions.ResourceNotFoundError` e.g. ID doesn't match any records
 ///     - 404: `bauplan.exceptions.ApiRouteError` e.g. the given route doesn't exist
 ///     - 405: `bauplan.exceptions.ApiMethodError` e.g. POST on a route with only GET defined
 ///     - 409: `bauplan.exceptions.UpdateConflictError` e.g. creating a record with a name that already exists
 ///     - 429: `bauplan.exceptions.TooManyRequestsError`
 ///
-/// Run/Query/Scan/Import operations raise a subclass of `bauplan.exceptions.BauplanError` that represents, and also return a `bauplan.state.RunState` object containing details and logs:
-///     - `bauplan.exceptions.JobError` e.g. something went wrong in a run/query/import/scan; includes error details
+/// Run/Query/Scan/Import operations raise a subclass of `bauplan.exceptions.BauplanError` that represents the error, and also return a `bauplan.state.RunState` object containing details and logs:
+///     - `bauplan.exceptions.BauplanJobError` e.g. something went wrong in a run/query/import/scan; includes error details
 ///
 /// Run/import operations also return a state object that includes a `job_status` and other details.
 /// There are two ways to check status for run/import operations:
-///     1. try/except `bauplan.exceptions.JobError`
+///     1. try/except `bauplan.exceptions.BauplanJobError`
 ///     2. check the `state.job_status` attribute
 ///
 /// ## Examples
@@ -119,8 +119,6 @@ impl ClientError {
 ///     api_key: Your unique Bauplan API key; mutually exclusive with `profile`. If not provided, fetch precedence is 1) environment `BAUPLAN_API_KEY` 2) .bauplan/config.yml
 ///     client_timeout: The client timeout in seconds for all the requests.
 ///     config_file_path: The path to the Bauplan config file to use. If not provided, ~/.bauplan/config.yaml will be used. Note that this disables any environment-based configuration.
-///
-///     feature_flags: A dictionary of feature flags to enable or disable during the use of this client instance.
 #[pyclass]
 pub(crate) struct Client {
     pub(crate) profile: Profile,

--- a/src/python/query.rs
+++ b/src/python/query.rs
@@ -71,7 +71,7 @@ impl Client {
             return Err(query_err("response missing job ID"));
         };
 
-        info!(job_id, "succesfully planned query");
+        info!(job_id, "successfully planned query");
 
         let mut client_clone = self.grpc.clone();
         let mut req = tonic::Request::new(commanderpb::SubscribeLogsRequest {

--- a/src/python/table.rs
+++ b/src/python/table.rs
@@ -50,9 +50,9 @@ impl<'a, 'py> FromPyObject<'a, 'py> for TableArg {
 impl Client {
     /// Create a table from an S3 location.
     ///
-    /// This operation will attempt to create a table based of schemas of N
+    /// This operation will attempt to create a table based on schemas of N
     /// parquet files found by a given search uri. This is a two step operation using
-    /// `plan_table_creation ` and  `apply_table_creation_plan`.
+    /// `plan_table_creation` and `apply_table_creation_plan`.
     ///
     /// ```python notest
     /// import bauplan
@@ -68,7 +68,7 @@ impl Client {
     /// Parameters:
     ///     table: The table which will be created.
     ///     search_uri: The location of the files to scan for schema.
-    ///     branch: The branch name in which to create the table in.
+    ///     branch: The branch name in which to create the table.
     ///     namespace: Optional argument specifying the namespace. If not specified, it will be inferred based on table location or the default.
     ///     partitioned_by: Optional argument specifying the table partitioning.
     ///     replace: Replace the table if it already exists.
@@ -193,9 +193,9 @@ impl Client {
 
     /// Create a table import plan from an S3 location.
     ///
-    /// This operation will attempt to create a table based of schemas of N
+    /// This operation will attempt to create a table based on schemas of N
     /// parquet files found by a given search uri. A YAML file containing the
-    /// schema and plan is returns and if there are no conflicts, it is
+    /// schema and plan is returned and if there are no conflicts, it is
     /// automatically applied.
     ///
     /// ```python notest
@@ -216,7 +216,7 @@ impl Client {
     /// Parameters:
     ///     table: The table which will be created.
     ///     search_uri: The location of the files to scan for schema.
-    ///     branch: The branch name in which to create the table in.
+    ///     branch: The branch name in which to create the table.
     ///     namespace: Optional argument specifying the namespace. If not specified, it will be inferred based on table location or the default.
     ///     partitioned_by: Optional argument specifying the table partitioning.
     ///     replace: Replace the table if it already exists.
@@ -331,11 +331,11 @@ impl Client {
         })
     }
 
-    /// Apply a plan for creating a table. It is done automaticaly during th
+    /// Apply a plan for creating a table. It is done automatically during the
     /// table plan creation if no schema conflicts exist. Otherwise, if schema
     /// conflicts exist, then this function is used to apply them after the
-    /// schema conflicts are resolved. Most common schema conflict is a two
-    /// parquet files with the same column name but different datatype
+    /// schema conflicts are resolved. The most common schema conflict is two
+    /// parquet files with the same column name but different datatypes.
     ///
     /// Parameters:
     ///     plan: The plan to apply.
@@ -436,10 +436,10 @@ impl Client {
     /// ```
     ///
     /// Parameters:
-    ///     table: Previously created table in into which data will be imported.
-    ///     search_uri: Uri which to scan for files to import.
+    ///     table: Previously created table into which data will be imported.
+    ///     search_uri: URI to scan for files to import.
     ///     branch: Branch in which to import the table.
-    ///     namespace: Namespace of the table. If not specified, namespace will be infered from table name or default settings.
+    ///     namespace: Namespace of the table. If not specified, namespace will be inferred from table name or default settings.
     ///     continue_on_error: Do not fail the import even if 1 data import fails.
     ///     import_duplicate_files: Ignore prevention of importing s3 files that were already imported.
     ///     best_effort: Don't fail if schema of table does not match.

--- a/tests/fixtures/parallel_models/models.py
+++ b/tests/fixtures/parallel_models/models.py
@@ -90,11 +90,11 @@ def parallel_grand_child_1(
 ):
     print('grand child 1 row count:', table_in.num_rows)
     if grand_child_1_should_sleep:
-        print('child 3 sleep')
+        print('grand child 1 sleep')
         time.sleep(1.5)
 
     if grand_child_1_should_fail:
-        raise Exception('child_3 threw exception')
+        raise Exception('grand_child_1 threw exception')
 
     return table_in
 
@@ -107,5 +107,5 @@ def parallel_great_grand_child_1(
         columns=['*'],
     ),
 ):
-    print('greate grand child 1 row count:', table_in.num_rows)
+    print('great grand child 1 row count:', table_in.num_rows)
     return table_in

--- a/tests/fixtures/parquet_field_ids/models.py
+++ b/tests/fixtures/parquet_field_ids/models.py
@@ -22,7 +22,7 @@ def parent(
     # the scan should not have field ids either
     assert_no_parquet_field_ids(trips)
 
-    # now let's simlate as if the table somehow ended having field ids added by the user
+    # now let's simulate as if the table somehow ended having field ids added by the user
     # (even though this will likely never happen in practice)
 
     import pyarrow as pa


### PR DESCRIPTION
Fix typos in docstrings, help text, comments, and config across Rust bindings, CLI, proto files, Python SDK, and test fixtures.