### PR TITLE
fix(cli): fix a runtime error in 'parameter set --type secret'

### DIFF
--- a/src/cli/parameter.rs
+++ b/src/cli/parameter.rs
@@ -178,11 +178,18 @@ fn set_parameter(cli: &Cli, args: ParameterSetArgs) -> anyhow::Result<()> {
             ParameterType::Secret => {
                 // Fetch the org-wide public key from commander.
                 let timeout = cli.timeout.unwrap_or(time::Duration::from_secs(5));
-                let mut client = grpc::Client::new_lazy(&cli.profile, timeout)?;
 
                 let req = cli.traced(commanderpb::GetBauplanInfoRequest::default());
-                let (key_name, key) =
-                    with_rt(client.org_default_public_key(req)).map_err(format_grpc_status)?;
+                let (key_name, key) = with_rt(async {
+                    let mut client = grpc::Client::new_lazy(&cli.profile, timeout)?;
+
+                    client
+                        .org_default_public_key(req)
+                        .await
+                        .map_err(format_grpc_status)
+                        .context("Failed to fetch organization-default public key")
+                })?;
+
                 ParameterValue::encrypt_secret(key_name, &key, project.project.id, v)?
             }
             _ => parse_parameter(param.param_type, &v)?,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -8,6 +8,7 @@ mod cli {
     mod branch;
     mod import;
     mod job;
+    mod parameter;
     mod query;
     mod run;
     mod table;

--- a/tests/cli/parameter.rs
+++ b/tests/cli/parameter.rs
@@ -1,0 +1,33 @@
+use crate::bauplan;
+use predicates::str::contains;
+
+#[test]
+fn set_secret_parameter() {
+    let tmp = tempfile::tempdir().unwrap();
+    for entry in std::fs::read_dir("tests/fixtures/parameters").unwrap() {
+        let entry = entry.unwrap();
+        std::fs::copy(entry.path(), tmp.path().join(entry.file_name())).unwrap();
+    }
+
+    let p = tmp.path().to_str().unwrap();
+
+    bauplan()
+        .args([
+            "parameter",
+            "set",
+            "--type",
+            "secret",
+            "-p",
+            p,
+            "test_secret",
+            "some-value",
+        ])
+        .assert()
+        .success();
+
+    bauplan()
+        .args(["parameter", "ls", "-p", p])
+        .assert()
+        .success()
+        .stdout(contains("test_secret"));
+}


### PR DESCRIPTION
We were initializing the runtime after the client, which panicked.