### PR TITLE
docs(pysdk): correctly case a column in an example

### DIFF
--- a/python/bauplan/_internal/__init__.pyi
+++ b/python/bauplan/_internal/__init__.pyi
@@ -1275,7 +1275,7 @@ class Client:
             table='titanic',
             ref='my_ref_or_branch_name',
             namespace='bauplan',
-            columns=['name'],
+            columns=['Name'],
             filters='Age < 30',
         )
         ```


### PR DESCRIPTION
The column is 'Name', not 'name'.