### PR TITLE
chore: update uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pyarrow", specifier = ">=23.0.0" }]
+requires-dist = [{ name = "pyarrow", specifier = ">=15.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
In af98d5d5633612e4f753bdcfd3ec79df452364bd, we relaxed the pyarrow requirement, but I forgot to ran `uv lock`.