### PR TITLE
test(cli): remove a stray comma in a query

### DIFF
--- a/tests/cli/query.rs
+++ b/tests/cli/query.rs
@@ -88,7 +88,7 @@ fn string_view() {
             "query",
             "--cache",
             "off",
-            "SELECT CONCAT(hvfhs_license_num, 'foobar') as license, FROM taxi_fhvhv LIMIT 5",
+            "SELECT CONCAT(hvfhs_license_num, 'foobar') as license FROM taxi_fhvhv LIMIT 5",
         ])
         .assert()
         .success()


### PR DESCRIPTION
This was working before, but upstream has started being more picky.