### PR TITLE
docs(pysdk): add examples

### DIFF
--- a/python/bauplan/__init__.pyi
+++ b/python/bauplan/__init__.pyi
@@ -490,6 +490,22 @@ class Client:
         )
         ```
 
+        To specify partitioning, use the `create_table` method with the `partitioned_by` parameter:
+
+        ```python
+        import bauplan
+
+        client = bauplan.Client()
+
+        # Create a partitioned table
+        table = client.create_table(
+            table='my_partitioned_table',
+            search_uri='s3://your-bucket/data/*.parquet',
+            partitioned_by="hour(tpep_pickup_datetime), PULocationID",
+            branch='my_branch'
+        )
+        ```
+
         Parameters:
             table: The table which will be created.
             search_uri: The location of the files to scan for schema.
@@ -1409,6 +1425,33 @@ class Client:
             print(f"Plan failed: {plan_state.error}")
         else:
             print(plan_state.plan)
+        ```
+
+        To manually add partitioning to a plan before applying it:
+
+        ```python
+        import yaml
+        import bauplan
+
+        client = bauplan.Client()
+
+        plan_state = client.plan_table_creation(
+            table='my_partitioned_table',
+            search_uri='s3://your-data/*.parquet',
+            branch='my_branch',
+        )
+
+        # Modify plan to add partitioning
+        plan = yaml.safe_load(plan_state.plan)
+        plan['schema_info']['partitions'] = [
+            {
+                'from_column_name': 'datetime_column',
+                'transform': {'name': 'year'},
+            }
+        ]
+
+        # Apply the modified plan
+        client.apply_table_creation_plan(yaml.dump(plan))
         ```
 
         Parameters:

--- a/python/bauplan/state.pyi
+++ b/python/bauplan/state.pyi
@@ -145,6 +145,28 @@ class TableCreatePlanContext:
 
 @final
 class TableCreatePlanState:
+    """
+    The result of a `plan_table_creation` call.
+
+    The `plan` field contains the schema plan as a YAML string. You can modify
+    it before applying, for example to add partitioning:
+
+    ```python
+    import bauplan
+    import yaml
+
+    client = bauplan.Client()
+    plan_state = client.plan_table_creation('my_table', 's3://bucket/path/*.parquet')
+    plan = yaml.safe_load(plan_state.plan)
+    plan['schema_info']['partitions'] = [
+        {
+            'from_column_name': 'datetime_column',
+            'transform': {'name': 'year'},
+        }
+    ]
+    modified_plan = yaml.dump(plan)
+    ```
+    """
     def __repr__(self, /) -> str: ...
     @property
     def can_auto_apply(self, /) -> bool: ...

--- a/src/python/run/state.rs
+++ b/src/python/run/state.rs
@@ -118,6 +118,26 @@ pub(crate) struct TableCreatePlanContext {
     pub search_string: String,
 }
 
+/// The result of a `plan_table_creation` call.
+///
+/// The `plan` field contains the schema plan as a YAML string. You can modify
+/// it before applying, for example to add partitioning:
+///
+/// ```python
+/// import bauplan
+/// import yaml
+///
+/// client = bauplan.Client()
+/// plan_state = client.plan_table_creation('my_table', 's3://bucket/path/*.parquet')
+/// plan = yaml.safe_load(plan_state.plan)
+/// plan['schema_info']['partitions'] = [
+///     {
+///         'from_column_name': 'datetime_column',
+///         'transform': {'name': 'year'},
+///     }
+/// ]
+/// modified_plan = yaml.dump(plan)
+/// ```
 #[derive(Clone)]
 #[pyclass(
     name = "TableCreatePlanState",

--- a/src/python/table.rs
+++ b/src/python/table.rs
@@ -65,6 +65,22 @@ impl Client {
     /// )
     /// ```
     ///
+    /// To specify partitioning, use the `create_table` method with the `partitioned_by` parameter:
+    ///
+    /// ```python
+    /// import bauplan
+    ///
+    /// client = bauplan.Client()
+    ///
+    /// # Create a partitioned table
+    /// table = client.create_table(
+    ///     table='my_partitioned_table',
+    ///     search_uri='s3://your-bucket/data/*.parquet',
+    ///     partitioned_by="hour(tpep_pickup_datetime), PULocationID",
+    ///     branch='my_branch'
+    /// )
+    /// ```
+    ///
     /// Parameters:
     ///     table: The table which will be created.
     ///     search_uri: The location of the files to scan for schema.
@@ -213,6 +229,33 @@ impl Client {
     ///     print(f"Plan failed: {plan_state.error}")
     /// else:
     ///     print(plan_state.plan)
+    /// ```
+    ///
+    /// To manually add partitioning to a plan before applying it:
+    ///
+    /// ```python
+    /// import yaml
+    /// import bauplan
+    ///
+    /// client = bauplan.Client()
+    ///
+    /// plan_state = client.plan_table_creation(
+    ///     table='my_partitioned_table',
+    ///     search_uri='s3://your-data/*.parquet',
+    ///     branch='my_branch',
+    /// )
+    ///
+    /// # Modify plan to add partitioning
+    /// plan = yaml.safe_load(plan_state.plan)
+    /// plan['schema_info']['partitions'] = [
+    ///     {
+    ///         'from_column_name': 'datetime_column',
+    ///         'transform': {'name': 'year'},
+    ///     }
+    /// ]
+    ///
+    /// # Apply the modified plan
+    /// client.apply_table_creation_plan(yaml.dump(plan))
     /// ```
     ///
     /// Parameters:


### PR DESCRIPTION
Adding examples for partitioning, and plan's schema modification (this is inspired by the upcoming removal of our "Guides" section to make sure no data is lost).