### PR TITLE
docs: clean up more em dashes and prevent them more thoroughly

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -11,13 +11,13 @@ lint:
 
     # Don't even think about it.
     ! grep -rn '[—–]' \
-        --include="*.md" --include="*.mdx" \
-        docs/pages examples
+        --include="*.md" --include="*.mdx" --include "*.rs" --include "*.pyi" \
+        docs/pages examples python src
 
     # These are technically tests, but they just check the source.
     cargo test --test snippets
 
-    # Lint CI/CD
+    # Lint CI/CD.
     zizmor . --persona pedantic
 
 test: lint

--- a/src/api/table.rs
+++ b/src/api/table.rs
@@ -15,7 +15,12 @@ use crate::{
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(name = "TableField", module = "bauplan.schema", from_py_object, get_all)
+    pyo3::pyclass(
+        name = "TableField",
+        module = "bauplan.schema",
+        from_py_object,
+        get_all
+    )
 )]
 pub struct TableField {
     /// The field ID.
@@ -32,7 +37,12 @@ pub struct TableField {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(name = "PartitionField", module = "bauplan.schema", from_py_object, get_all)
+    pyo3::pyclass(
+        name = "PartitionField",
+        module = "bauplan.schema",
+        from_py_object,
+        get_all
+    )
 )]
 pub struct PartitionField {
     /// The partition field name.
@@ -630,8 +640,8 @@ mod test {
         };
         roundtrip(req)?;
 
-        // Now the table exists on the branch again. Try to revert without
-        // replace — should fail.
+        // Now the table exists on the branch again. Reverting without `replace`
+        // should fail.
         let req = RevertTable {
             name: "titanic",
             source_ref: "main",


### PR DESCRIPTION
The existing lint would let em dashes into the python docstrings, but then fail once the docs were generated from those docstrings (down the road).