### PR TITLE
docs: Generate SDK reference from local folder

### DIFF
--- a/docs/Justfile
+++ b/docs/Justfile
@@ -7,6 +7,15 @@ generate:
     bun run generate-llm-docs
     bun run generate-llms-txt
 
+# Generate SDK reference from the local bauplan source (../python) instead of the released package.
+generate-local bauplan_path="../python":
+    BAUPLAN_LOCAL_PATH="{{ bauplan_path }}" uv run gen_sdk_reference.py
+    bun run generate-llm-docs
+    bun run generate-llms-txt
+
+serve-local: install generate-local
+    bun run docusaurus start
+
 build out_dir="./build": install generate
     bun run docusaurus build --out-dir "{{ out_dir }}"
 

--- a/docs/gen_sdk_reference.py
+++ b/docs/gen_sdk_reference.py
@@ -3,6 +3,7 @@
 import html
 import json
 import logging
+import os
 import re
 from contextlib import contextmanager
 from pathlib import Path
@@ -407,7 +408,11 @@ def main() -> None:
     output_dir = Path(__file__).parent / 'pages' / 'reference'
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    bauplan = griffe.load('bauplan')
+    local_path = os.getenv('BAUPLAN_LOCAL_PATH')
+    kwargs = {'search_paths': [local_path]} if local_path else {}
+    if local_path:
+        logging.info('Loading bauplan from local path: %s', local_path)
+    bauplan = griffe.load('bauplan', **kwargs)
 
     assert isinstance(bauplan, griffe.Module)
     linker = TypeLinker()


### PR DESCRIPTION
Generate SDK reference from local folder
- Adds a new target that generates the SDK reference from the local folder instead of the installed binary.
This is useful during development and when working on docstrings.