### PR TITLE
build: exit 1 on vale warnings

### DIFF
--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -7,8 +7,8 @@ on:
       - .github/workflows/vale.yaml
       - .vale.ini
       - styles/**
-      - docs/pages/*.md
-      - docs/pages/*.mdx
+      - docs/pages/**/*.md
+      - docs/pages/**/*.mdx
       - examples/**/*.md
 
 permissions:

--- a/Justfile
+++ b/Justfile
@@ -6,8 +6,10 @@ lint:
     cargo clippy -- -Dwarnings
 
     # Prose linting.
+    # https://github.com/vale-cli/vale/issues/575
     vale sync
-    vale docs/pages examples --minAlertLevel warning
+    vale docs/pages examples --minAlertLevel warning |\
+        awk 'BEGIN {status = 1} 1; END {if(/^✔/) status = 0; exit(status)}'
 
     # Don't even think about it.
     ! grep -rn '[—–]' \

--- a/docs/pages/common-scenarios/branching-workflows.mdx
+++ b/docs/pages/common-scenarios/branching-workflows.mdx
@@ -2,7 +2,7 @@
 title: "Branching Workflows"
 ---
 
-# Branching Workflows
+# Branching workflows
 
 ## Overview
 
@@ -12,7 +12,7 @@ There are two recommended patterns for integrating work into production. Both ar
 
 ---
 
-## Approach 1: Data-First
+## Approach 1: Data-first
 
 **Philosophy:** _“Trust the data. If the output looks right in the branch, promote it directly.”_
 
@@ -35,7 +35,7 @@ You trust that the branch environment is representative enough. If the data in t
 
 ---
 
-## Approach 2: Code-First
+## Approach 2: Code-first
 
 **Philosophy:** _“Trust the code. The branch is proof the code works; re-run transactionally in main for full assurance.”_
 
@@ -59,7 +59,7 @@ You compute tables twice (once in the branch, once in main), which uses more com
 
 ---
 
-## Side-by-Side Comparison
+## Side-by-side comparison
 
 |                       | Data-First                        | Code-First                          |
 | --------------------- | --------------------------------- | ----------------------------------- |
@@ -72,7 +72,7 @@ You compute tables twice (once in the branch, once in main), which uses more com
 
 ---
 
-## Key Concept: Why This Works
+## Why this works
 
 In Bauplan, **the only way to change data is by running code**. This is a fundamental design principle. It means:
 

--- a/docs/pages/common-scenarios/detached-runs.mdx
+++ b/docs/pages/common-scenarios/detached-runs.mdx
@@ -19,7 +19,7 @@ During interactive development, attached mode ([`bauplan run`](/reference/baupla
 real-time feedback. Once a pipeline moves to production, detached mode
 is the recommended approach.
 
-## Running in Detached Mode
+## Running in detached mode
 
 **For regular runs:**
 
@@ -86,7 +86,7 @@ The job ID is available on the returned state object via `.job_id`.
 </Tabs>
 </div>
 
-## Checking Job Status
+## Checking job status
 
 <div id="detached-runs-status">
 <Tabs groupId="cli-sdk">
@@ -154,7 +154,7 @@ for job in client.get_jobs(
 </Tabs>
 </div>
 
-## Retrieving Job Output
+## Retrieving job output
 
 Logs are persisted for 24 hours as a way to troubleshoot jobs, after
 which they are deleted.
@@ -186,7 +186,7 @@ for log_line in logs:
 </Tabs>
 </div>
 
-## Cancel a Job
+## Cancel a job
 
 To cancel a running job, use the CLI or SDK. When a job is
 successfully cancelled, its status changes to `Aborted`.

--- a/docs/pages/concepts/projects.mdx
+++ b/docs/pages/concepts/projects.mdx
@@ -91,7 +91,7 @@ parameters:
     default: true
 ```
 
-## Make it interesting: Notebooks, Apps, and Orchestrators
+## Make it interesting: notebooks, apps, and orchestrators
 
 Some pipelines benefit from interactive or external components:
 
@@ -100,7 +100,7 @@ Some pipelines benefit from interactive or external components:
 -   **[Orchestrators](/integrations/orchestrators/)** (for example, [Airflow](/integrations/orchestrators/airflow), [Prefect](/integrations/orchestrators/prefect)) used to schedule and
     monitor the pipelines in production.
 
-### Notebooks & Apps
+### Notebooks & apps
 
 The recommended project structure is:
 


### PR DESCRIPTION
Vale doesn't support this natively, so we have to hack around it.

The warnings were introduced in #167.