### PR TITLE
feat(pysdk): release Windows wheels for amd64 and arm64

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read # Clone repo at release tag
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         include:
@@ -36,6 +39,12 @@ jobs:
             arch: arm64
           - runner: macos-latest
             os: macos
+            arch: arm64
+          - runner: windows-latest
+            os: windows
+            arch: amd64
+          - runner: windows-11-arm
+            os: windows
             arch: arm64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -60,10 +69,12 @@ jobs:
         run: uv python install 3.10 3.11 3.12 3.13 3.14
 
       - name: Build CLI binary
+        env:
+          BIN_EXT: ${{ matrix.os == 'windows' && '.exe' || '' }}
         run: |
           cargo build --release --bin bauplan
           rm -f python/data/scripts/.gitkeep python/data/scripts/.gitignore
-          cp target/release/bauplan python/data/scripts/
+          cp "target/release/bauplan${BIN_EXT}" python/data/scripts/
 
       - name: Build wheels
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
@@ -89,9 +100,10 @@ jobs:
           TAG: ${{ inputs.tag }}
           OS: ${{ matrix.os }}
           ARCH: ${{ matrix.arch }}
+          BIN_EXT: ${{ matrix.os == 'windows' && '.exe' || '' }}
         run: |
           mkdir -p "${RUNNER_TEMP}/${TAG}"
-          cp target/release/bauplan README.md CHANGELOG.md LICENSE* \
+          cp "target/release/bauplan${BIN_EXT}" README.md CHANGELOG.md LICENSE* \
             "${RUNNER_TEMP}/${TAG}"
           tar -C "${RUNNER_TEMP}" --numeric-owner \
             -cvzf "bauplan-${TAG}-${OS}-${ARCH}.tar.gz" "${TAG}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "License :: OSI Approved :: MIT License",
     "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Rust",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
Builds bauplan as a Python wheel for Windows on `amd64` and `arm64`, in addition to the existing `Linux` and `macOS` targets. The publish workflow gains two runners (`windows-latest` and `windows-11-arm`) and ships the resulting wheels to PyPI at release time like the others.
Each wheel includes `bauplan.exe` under `.data/scripts/`, the same way Linux and macOS wheels include `bauplan`.

If you ever need to rebuild a Windows wheel from a Mac or a Linux box to reproduce or debug a Windows-specific issue, cross compiling needs `cargo-xwin` plus the LLVM toolchain. One-time setup on macOS is

```bash
$ brew install llvm lld
$ cargo install --locked cargo-xwin
$ rustup target add x86_64-pc-windows-msvc
```

On Debian or Ubuntu swap the first command with `sudo apt install llvm lld clang`. Then, with the Microsoft MSVC EULA accepted via an env var:

```bash
export PATH="/opt/homebrew/opt/llvm/bin:$PATH"   # macOS only, llvm is keg-only on brew
export XWIN_ACCEPT_LICENSE=1

cargo xwin build --release --bin bauplan --target x86_64-pc-windows-msvc
cp target/x86_64-pc-windows-msvc/release/bauplan.exe python/data/scripts/
CARGO_BUILD_TARGET=x86_64-pc-windows-msvc uv build --wheel --python 3.12 --out-dir dist
```

For the cross compile to link you also need to temporarily add `"pyo3/generate-import-lib"` to the `python` feature in `Cargo.toml`, because `python312.lib` is not available outside of a real Windows install.
The CI does not need this since it builds natively on Windows runners where `python-build-standalone` provides the lib, so the feature is not checked in.

To test the wheel on a clean Windows 10 or 11 machine, open `PowerShell`, install a matching Python with `winget install -e --id Python.Python.3.12`, close and reopen PowerShell so `PATH` refreshes, copy the `.whl` to the
machine and then:

```powershell
cd $env:USERPROFILE\Desktop\
py -3.12 -m venv bautest
Set-ExecutionPolicy -Scope CurrentUser RemoteSigned   # first time only, lets Activate.ps1 run
.\bautest\Scripts\Activate.ps1
pip install .\bauplan-0.1.10-cp312-cp312-win_amd64.whl
python -c "import bauplan; print(bauplan.Client)"

bauplan --version
bauplan --help
```

If you want to hit a real backend, drop a config at `%USERPROFILE%\.bauplan\config.yaml`, then `bauplan query "SELECT 1"`.