### PR TITLE
Document CLI defaults more consistently

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -51,6 +51,15 @@ pub(crate) enum Output {
     Tty,
 }
 
+impl std::fmt::Display for Output {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Output::Json => write!(f, "json"),
+            Output::Tty => write!(f, "tty"),
+        }
+    }
+}
+
 /// A priority for a job, from 1-10, where 10 is the highest.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub(crate) struct Priority(u32);
@@ -125,8 +134,8 @@ pub(crate) struct GlobalArgs {
     #[arg(long, short = 'P', global = true)]
     pub profile: Option<String>,
     /// Output format
-    #[arg(long, short = 'O', global = true)]
-    pub output: Option<Output>,
+    #[arg(long, short = 'O', global = true, default_value_t = Output::default())]
+    pub output: Output,
     /// Timeout (in seconds) for client operations (-1 = no timeout)
     #[arg(long, global = true)]
     pub client_timeout: Option<i64>,

--- a/src/cli/branch.rs
+++ b/src/cli/branch.rs
@@ -234,7 +234,7 @@ fn list_branches(cli: &Cli, args: BranchLsArgs) -> anyhow::Result<()> {
 
     let branches = bauplan::paginate(req, limit, |r| cli.roundtrip(r))?;
 
-    match cli.global.output.unwrap_or_default() {
+    match cli.global.output {
         Output::Json => {
             let all_branches = branches.collect::<anyhow::Result<Vec<_>>>()?;
             serde_json::to_writer(stdout(), &all_branches)?;
@@ -281,7 +281,7 @@ fn get_branch(cli: &Cli, args: BranchGetArgs) -> anyhow::Result<()> {
 
     let tables = bauplan::paginate(req, None, |r| cli.roundtrip(r))?;
 
-    match cli.global.output.unwrap_or_default() {
+    match cli.global.output {
         Output::Json => {
             let all_tables = tables.collect::<anyhow::Result<Vec<_>>>()?;
             serde_json::to_writer(stdout(), &all_tables)?;
@@ -427,7 +427,7 @@ fn diff_branch(cli: &Cli, args: BranchDiffArgs) -> anyhow::Result<()> {
     let tables_a = collect_tables(cli, branch_a, namespace.as_deref())?;
     let tables_b = collect_tables(cli, branch_b, namespace.as_deref())?;
 
-    match cli.global.output.unwrap_or_default() {
+    match cli.global.output {
         Output::Json => {
             let added: Vec<_> = tables_b
                 .iter()

--- a/src/cli/commit.rs
+++ b/src/cli/commit.rs
@@ -15,6 +15,18 @@ pub(crate) enum Format {
     Fuller,
 }
 
+impl std::fmt::Display for Format {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Format::Oneline => write!(f, "oneline"),
+            Format::Short => write!(f, "short"),
+            Format::Medium => write!(f, "medium"),
+            Format::Full => write!(f, "full"),
+            Format::Fuller => write!(f, "fuller"),
+        }
+    }
+}
+
 #[derive(Debug, clap::Args)]
 #[command(after_long_help = CliExamples("
   # Show recent commits on active branch
@@ -57,8 +69,8 @@ pub(crate) struct CommitArgs {
     #[arg(short = 'n', long, visible_alias = "limit", default_value = "10")]
     pub max_count: usize,
     /// How to format commits.
-    #[arg(long, alias = "pretty")]
-    pub format: Option<Format>,
+    #[arg(long, default_value_t = Format::default(), alias = "pretty")]
+    pub format: Format,
 }
 
 pub(crate) fn handle(cli: &Cli, args: CommitArgs) -> anyhow::Result<()> {
@@ -100,7 +112,7 @@ pub(crate) fn handle(cli: &Cli, args: CommitArgs) -> anyhow::Result<()> {
 
     let commits = bauplan::paginate(req, Some(args.max_count), |r| cli.roundtrip(r))?;
 
-    match cli.global.output.unwrap_or_default() {
+    match cli.global.output {
         Output::Json => {
             let all_commits = commits.collect::<anyhow::Result<Vec<_>>>()?;
             serde_json::to_writer(stdout(), &all_commits)?;
@@ -110,7 +122,7 @@ pub(crate) fn handle(cli: &Cli, args: CommitArgs) -> anyhow::Result<()> {
             let mut out = anstream::stdout().lock();
             for commit in commits {
                 let commit = commit?;
-                print_commit(&mut out, &commit, args.format.unwrap_or_default())?;
+                print_commit(&mut out, &commit, args.format)?;
             }
         }
     }

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -103,7 +103,7 @@ fn config_set(args: ConfigSetArgs, global: GlobalArgs) -> anyhow::Result<()> {
 fn config_get(args: ConfigGetArgs, global: GlobalArgs) -> anyhow::Result<()> {
     let mut out = anstream::stdout().lock();
 
-    match (global.output.unwrap_or_default(), args.all) {
+    match (global.output, args.all) {
         (Output::Tty, false) => {
             let profile = match global.profile {
                 Some(name) => Profile::from_env(&name)?,

--- a/src/cli/job.rs
+++ b/src/cli/job.rs
@@ -294,7 +294,7 @@ async fn handle_ls(cli: &Cli, args: JobLsArgs) -> anyhow::Result<()> {
     .try_flatten()
     .map_ok(Job::from);
 
-    match cli.global.output.unwrap_or_default() {
+    match cli.global.output {
         Output::Json => {
             let jobs: Vec<Job> = stream.try_collect().await?;
             serde_json::to_writer(stdout(), &jobs)?;
@@ -382,7 +382,7 @@ async fn handle_get(cli: &Cli, args: JobGetArgs) -> anyhow::Result<()> {
         bail!("job not found: {}", args.job_id);
     };
 
-    match cli.global.output.unwrap_or_default() {
+    match cli.global.output {
         Output::Json => {
             serde_json::to_writer(stdout(), &[job])?;
             println!();
@@ -474,7 +474,7 @@ async fn handle_logs(cli: &Cli, args: JobLogsArgs) -> anyhow::Result<()> {
         }
     });
 
-    match cli.global.output.unwrap_or_default() {
+    match cli.global.output {
         Output::Json => {
             serde_json::to_writer(stdout(), &entries.collect::<Vec<_>>())?;
             println!();

--- a/src/cli/namespace.rs
+++ b/src/cli/namespace.rs
@@ -123,7 +123,7 @@ fn list_namespaces(
 
     let namespaces = bauplan::paginate(req, limit, |r| cli.roundtrip(r))?;
 
-    match cli.global.output.unwrap_or_default() {
+    match cli.global.output {
         Output::Json => {
             let all_namespaces = namespaces.collect::<anyhow::Result<Vec<_>>>()?;
             serde_json::to_writer(stdout(), &all_namespaces)?;

--- a/src/cli/parameter.rs
+++ b/src/cli/parameter.rs
@@ -62,7 +62,7 @@ pub(crate) enum ParameterCommand {
 "))]
 pub(crate) struct ParameterLsArgs {
     /// Path to the root Bauplan project directory.
-    #[arg(short, long)]
+    #[arg(short, long, default_value = ".")]
     pub project_dir: Option<PathBuf>,
 }
 
@@ -78,7 +78,7 @@ pub(crate) struct ParameterRmArgs {
     /// Name of the parameter to remove
     pub name: String,
     /// Path to the root Bauplan project directory.
-    #[arg(short, long)]
+    #[arg(short, long, default_value = ".")]
     pub project_dir: Option<PathBuf>,
 }
 
@@ -123,7 +123,7 @@ pub(crate) struct ParameterSetArgs {
     #[arg(short, long)]
     pub file: Option<PathBuf>,
     /// Path to the root Bauplan project directory.
-    #[arg(short, long)]
+    #[arg(short, long, default_value = ".")]
     pub project_dir: Option<PathBuf>,
 }
 

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -51,8 +51,8 @@ pub(crate) struct QueryArgs {
     #[arg(short, long, conflicts_with = "sql")]
     pub file: Option<PathBuf>,
     /// Set the cache mode.
-    #[arg(long)]
-    pub cache: Option<OnOff>,
+    #[arg(long, default_value_t = OnOff::On)]
+    pub cache: OnOff,
     /// Limit number of returned rows. (use --all-rows to disable this)
     #[arg(long, default_value = "10")]
     pub max_rows: Option<u64>,
@@ -114,7 +114,7 @@ pub(crate) async fn handle(cli: &Cli, args: QueryArgs) -> anyhow::Result<()> {
         job_request_common: Some(job_request_common),
         r#ref,
         sql_query,
-        cache: cache.unwrap_or(OnOff::On).to_string(),
+        cache: cache.to_string(),
         namespace,
     };
 
@@ -180,7 +180,7 @@ pub(crate) async fn handle(cli: &Cli, args: QueryArgs) -> anyhow::Result<()> {
     futures::pin_mut!(batches);
 
     progress.finish_with_done();
-    match cli.global.output.unwrap_or_default() {
+    match cli.global.output {
         Output::Tty => print_tty(schema, batches, !no_trunc).await,
         Output::Json => print_json(batches, &job_id).await,
     }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -66,7 +66,7 @@ impl Display for Preview {
 "))]
 pub(crate) struct RunArgs {
     /// Path to the root Bauplan project directory.
-    #[arg(short, long)]
+    #[arg(short, long, default_value = ".")]
     pub project_dir: Option<PathBuf>,
     /// Ref or branch name from which to run the job [default: active branch]
     #[arg(short, long)]
@@ -75,17 +75,17 @@ pub(crate) struct RunArgs {
     #[arg(short, long)]
     pub namespace: Option<String>,
     /// Set the cache mode.
-    #[arg(long)]
-    pub cache: Option<OnOff>,
+    #[arg(long, default_value_t = OnOff::On)]
+    pub cache: OnOff,
     /// Set the preview mode.
-    #[arg(long)]
-    pub preview: Option<Preview>,
+    #[arg(long, default_value_t = Preview::default())]
+    pub preview: Preview,
     /// Exit upon encountering runtime warnings (e.g., invalid column output)
-    #[arg(long)]
-    pub strict: Option<OnOff>,
+    #[arg(long, default_value_t = OnOff::Off)]
+    pub strict: OnOff,
     /// Run the dag as a transaction. Will create a temporary branch where models are materialized. Once all models succeed, it will be merged to the branch in which this run is happening
-    #[arg(short, long)]
-    pub transaction: Option<OnOff>,
+    #[arg(short, long, default_value_t = OnOff::On)]
+    pub transaction: OnOff,
     /// Dry run the job without materializing any models.
     #[arg(long)]
     pub dry_run: bool,
@@ -302,10 +302,10 @@ async fn handle_run(cli: &Cli, args: RunArgs) -> anyhow::Result<()> {
         r#ref,
         namespace,
         dry_run,
-        transaction: transaction.unwrap_or(OnOff::On).to_string(),
-        strict: strict.unwrap_or(OnOff::Off).to_string(),
-        cache: cache.unwrap_or(OnOff::On).to_string(),
-        preview: preview.unwrap_or_default().to_string(),
+        transaction: transaction.to_string(),
+        strict: strict.to_string(),
+        cache: cache.to_string(),
+        preview: preview.to_string(),
         project_id: project.project.id.as_hyphenated().to_string(),
         project_name: project.project.name.clone().unwrap_or_default(),
         parameters,
@@ -500,7 +500,7 @@ async fn handle_run(cli: &Cli, args: RunArgs) -> anyhow::Result<()> {
         }
     }
 
-    if cli.global.output == Some(crate::cli::Output::Json) {
+    if cli.global.output == crate::cli::Output::Json {
         // Redirect any further writes to stderr, so that they don't get
         // interleaved with the json to stdout.
         cli.multiprogress

--- a/src/cli/table.rs
+++ b/src/cli/table.rs
@@ -383,7 +383,7 @@ fn handle_list_tables(
 
     let tables = bauplan::paginate(req, limit, |r| cli.roundtrip(r))?;
 
-    match cli.global.output.unwrap_or_default() {
+    match cli.global.output {
         Output::Json => {
             let all_tables = tables.collect::<anyhow::Result<Vec<_>>>()?;
             serde_json::to_writer(stdout(), &all_tables)?;
@@ -422,7 +422,7 @@ fn handle_get_table(
     };
 
     let resp = cli.roundtrip(req)?;
-    match cli.global.output.unwrap_or_default() {
+    match cli.global.output {
         Output::Json => {
             serde_json::to_writer(stdout(), &resp)?;
             println!();

--- a/src/cli/tag.rs
+++ b/src/cli/tag.rs
@@ -110,7 +110,7 @@ fn list_tags(cli: &Cli, TagLsArgs { name, limit }: TagLsArgs) -> anyhow::Result<
 
     let tags = bauplan::paginate(req, limit, |r| cli.roundtrip(r))?;
 
-    match cli.global.output.unwrap_or_default() {
+    match cli.global.output {
         Output::Json => {
             let all_tags = tags.collect::<anyhow::Result<Vec<_>>>()?;
             serde_json::to_writer(stdout(), &all_tags)?;


### PR DESCRIPTION
This PR makes CLI defaults more explicit and consistent in help output.

Changes:
- Set explicit Clap defaults for run options that already have runtime defaults:
      - `--cache`
      - `--preview`
      - `--strict`
      - `--transaction`
- Set `--project-dir` default to `.` for:
      - run
      - parameter ls
      - parameter rm
      - parameter set
- Set commit `--format` to default to medium
- Set query `--cache` to default to on