### PR TITLE
docs(conflicts): add snippets and docs about conflicts

### DIFF
--- a/examples/learn/07-how-to-manage-conflicts/01_concurrency_conflict/README.md
+++ b/examples/learn/07-how-to-manage-conflicts/01_concurrency_conflict/README.md
@@ -1,0 +1,64 @@
+# Concurrency conflict
+
+Demonstrates the conflict that occurs when two users independently materialise the same table and race to publish it on `main`.
+
+User A and user B both branch off `main` when `workshop_average_fares` does not exist and run the same pipeline in isolation. User A merges first, publishing the table on `main`. When user B then tries to merge, Bauplan rejects the merge because `main` has moved on since user B branched.
+
+## Scenario
+
+```mermaid
+gitGraph
+   commit id: "main: no workshop_average_fares"
+   branch user_A
+   checkout main
+   branch user_B
+   checkout user_A
+   commit id: "user_A: create workshop_average_fares"
+   checkout user_B
+   commit id: "user_B: create workshop_average_fares"
+   checkout main
+   merge user_A id: "merge OK, table on main"
+```
+
+`user_B` now tries to merge into `main`, but Bauplan rejects it: both `main` and `user_B` independently introduce `workshop_average_fares` from different histories, so Bauplan cannot reconcile the merge automatically.
+
+## Pipelines
+
+| Pipeline | Source table | Groups by | Computes |
+|---|---|---|---|
+| `avg_fare` | `titanic` | `Pclass` | Mean fare per passenger class |
+
+## Usage
+
+```sh
+uv run main.py [OPTIONS]
+```
+
+Run `uv run main.py --help` to see all available options.
+
+### Options
+
+| Option | Default | Description |
+|---|---|---|
+| `--profile` | `default` | Bauplan profile to use. |
+
+### Expected output
+
+```
+User A opened branch <USER>.user_A
+User B opened branch <USER>.user_B
+User A pipeline succeeded on <USER>.user_A
+User B pipeline succeeded on <USER>.user_B
+User A merged into main
+User B failed to merge into main, as expected. Error: (409, 'MERGE_CONFLICT', 'Merge conflict between source branch "<USER>.user_B" and destination branch "<USER>.main": The following keys have been changed in conflict: \'bauplan.workshop_average_fares\'', <bauplan.exceptions.ApiErrorKind.MergeConflict object at 0x103d92430>)
+```
+
+## What to observe
+
+User A's merge succeeds and Bauplan publishes `workshop_average_fares` on `main`. Bauplan rejects User B's merge with a conflict, so `main` never ends up in an inconsistent state. User B should re-run the pipeline on a fresh branch off the new `main`.
+
+## Why this happens
+
+User A and user B both branch from the same `main` commit, where `workshop_average_fares` does not exist. They each materialise the table on their own branch in parallel. When user A merges, `main` transitions from "no table" to "user A's table" cleanly, because user A's branch history is a straightforward descendant of `main`.
+
+User B, however, branched from the same prior `main` commit. When user B tries to merge, Bauplan sees that both `main` and user B's branch independently introduce `workshop_average_fares` from different branch histories. It cannot reconcile the two, as they are concurrent creations of the same fully qualified name, so it rejects the merge to protect `main`'s history. This is exactly the correct behaviour: when Bauplan detects the race, it asks the second writer to "rebase" rather than silently overwrite the first writer's work.

--- a/examples/learn/07-how-to-manage-conflicts/01_concurrency_conflict/main.py
+++ b/examples/learn/07-how-to-manage-conflicts/01_concurrency_conflict/main.py
@@ -1,0 +1,106 @@
+import bauplan
+import typer
+from typing import Annotated
+
+TABLE_NAME = "workshop_average_fares"
+PIPELINE_PATH = "pipelines/avg_fare"
+
+
+def run_pipeline(client: bauplan.Client, branch: str) -> None:
+    """Run the pipeline on `branch` and raise if the job does not succeed."""
+    run_state = client.run(project_dir=PIPELINE_PATH, ref=branch)
+    if str(run_state.job_status).lower() != "success":
+        raise Exception(
+            f"{run_state.job_id} failed: {run_state.job_status} - {run_state.error}."
+        )
+
+
+def main(
+    profile: Annotated[str, typer.Option(help="Bauplan profile to use")] = "default",
+) -> None:
+    """
+    Demonstrate a concurrency conflict when two users independently create the same table.
+
+    The story, in order:
+      1. User A and user B both open their own branch off main at roughly the same time,
+         when `workshop_average_fares` does not yet exist.
+      2. Each user runs the same pipeline on their own branch.
+      3. User A merges first, publishing the table on main.
+      4. User B then tries to merge, but Bauplan rejects the merge because main has
+         moved on since user B branched off.
+    """
+    client = bauplan.Client(profile=profile)
+
+    username = client.info().user.username
+
+    # Use a "fake" main branch to avoid polluting main
+    example_main_branch = f"{username}.main"
+    client.delete_branch(branch=example_main_branch, if_exists=True)
+    client.create_branch(
+        branch=example_main_branch, from_ref="main", if_not_exists=True
+    )
+
+    # Reset the target table on the example main so the story always starts from a clean state
+    client.delete_table(table=TABLE_NAME, branch=example_main_branch, if_exists=True)
+
+    user_A_branch = f"{username}.user_A"
+    user_B_branch = f"{username}.user_B"
+
+    # Start from fresh branches so previous runs don't interfere
+    for b in (user_A_branch, user_B_branch):
+        client.delete_branch(branch=b, if_exists=True)
+
+    # --- Step 1: both users open a branch off main, roughly at the same time ---
+    # User A is about to start working on `workshop_average_fares`, which is not yet on main
+    client.create_branch(branch=user_A_branch, from_ref=example_main_branch)
+    print(f"User A opened branch {user_A_branch}")
+
+    # Meanwhile, user B independently starts working on the same table
+    client.create_branch(branch=user_B_branch, from_ref=example_main_branch)
+    print(f"User B opened branch {user_B_branch}")
+
+    # Nothing has been materialised yet, so the table does not exist anywhere
+    assert not client.has_table(table=TABLE_NAME, ref=example_main_branch)
+    assert not client.has_table(table=TABLE_NAME, ref=user_A_branch)
+    assert not client.has_table(table=TABLE_NAME, ref=user_B_branch)
+
+    # --- Step 2: user A runs the pipeline on his branch ---
+    run_pipeline(client, user_A_branch)
+    print(f"User A pipeline succeeded on {user_A_branch}")
+
+    # The table now exists on user A's branch, but main is untouched: user A hasn't merged yet
+    assert client.has_table(table=TABLE_NAME, ref=user_A_branch)
+    assert not client.has_table(table=TABLE_NAME, ref=example_main_branch)
+
+    # --- Step 3: user B runs the same pipeline on his own branch ---
+    run_pipeline(client, user_B_branch)
+    print(f"User B pipeline succeeded on {user_B_branch}")
+
+    # Both users now have their own copy of the table; main is still unchanged because nobody has merged yet
+    assert client.has_table(table=TABLE_NAME, ref=user_B_branch)
+    assert not client.has_table(table=TABLE_NAME, ref=example_main_branch)
+
+    # --- Step 4: user A merges first; main picks up the table ---
+    client.merge_branch(source_ref=user_A_branch, into_branch=example_main_branch)
+    print("User A merged into main")
+    assert client.has_table(table=TABLE_NAME, ref=example_main_branch)
+
+    # --- Step 5: user B tries to merge, but main has moved on ---
+    # User B branched when the table did not exist on main. Since then user A has
+    # published a table with that exact name, so main and user B's branch both independently
+    # introduce `workshop_average_fares` from different histories. Bauplan detects
+    # the divergence and rejects the merge rather than letting user B silently
+    # overwrite user A's work.
+    try:
+        client.merge_branch(source_ref=user_B_branch, into_branch=example_main_branch)
+        print("User B merged into main (unexpected)")
+    except Exception as e:
+        print(f"User B failed to merge into main, as expected. Error: {e}")
+
+    # Cleanup afterwards
+    for b in (user_A_branch, user_B_branch, example_main_branch):
+        client.delete_branch(branch=b, if_exists=True)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/examples/learn/07-how-to-manage-conflicts/01_concurrency_conflict/pipelines/avg_fare/bauplan_project.yaml
+++ b/examples/learn/07-how-to-manage-conflicts/01_concurrency_conflict/pipelines/avg_fare/bauplan_project.yaml
@@ -1,0 +1,3 @@
+project:
+  id: 20af3fc0-3164-46dc-acd3-279ccc356a3a
+  name: avg_fare

--- a/examples/learn/07-how-to-manage-conflicts/01_concurrency_conflict/pipelines/avg_fare/models.py
+++ b/examples/learn/07-how-to-manage-conflicts/01_concurrency_conflict/pipelines/avg_fare/models.py
@@ -1,0 +1,14 @@
+import bauplan
+
+
+@bauplan.python("3.12", pip={"polars": "1.37"})
+@bauplan.model(materialization_strategy="REPLACE")
+def workshop_average_fares(
+    data=bauplan.Model("titanic", columns=["Pclass", "Fare"]),
+):
+    """Compute the mean Titanic fare for each passenger class."""
+    import polars as pl
+
+    df = pl.from_arrow(data)
+
+    return df.group_by(pl.col("Pclass")).agg(pl.col("Fare").mean()).to_arrow()

--- a/examples/learn/07-how-to-manage-conflicts/01_concurrency_conflict/pipelines/avg_fare/pyproject.toml
+++ b/examples/learn/07-how-to-manage-conflicts/01_concurrency_conflict/pipelines/avg_fare/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "avg_Fare"
+requires-python = "~=3.12"
+dependencies = ["bauplan~=0.1.9"]

--- a/examples/learn/07-how-to-manage-conflicts/02_naming_conflict/README.md
+++ b/examples/learn/07-how-to-manage-conflicts/02_naming_conflict/README.md
@@ -1,0 +1,129 @@
+# Naming conflict
+
+Demonstrates the naming conflict that occurs when two pipelines write to the same table name, and how namespace isolation resolves it.
+
+User A and user B each produce a table called `workshop_average_fares` from different source datasets and schemas. The script runs two scenarios back to back.
+
+## Scenarios
+
+**Scenario #1. Same namespace:** both pipelines write to the default namespace. Both merges succeed, but user B silently overwrites user A's table on `main`. User A's schema and data no longer exist at the branch tip. *Note well*: user A's data is not technically gone forever, as Bauplan allows time-traveling: you can always recover the lake state before the user B merge!
+
+**Scenario #2. Different namespaces:** each pipeline writes to a user-specific namespace: `user_A_namespace` and `user_B_namespace`. Both tables coexist on `main` with no overwrite.
+
+### Scenario #1
+
+```mermaid
+gitGraph
+   commit id: "main: no workshop_average_fares"
+   branch user_A
+   checkout user_A
+   commit id: "user_A: create workshop_average_fares (titanic schema)"
+   checkout main
+   merge user_A id: "merge OK, table created on main"
+   branch user_B
+   checkout user_B
+   commit id: "user_B: create workshop_average_fares (taxi schema)"
+   checkout main
+   merge user_B id: "merge OK, table OVERWRITTEN silently"
+```
+
+### Scenario #2
+
+Each pipeline writes into its own namespace, which behaves like a directory. After both merges, `main` contains two separate "directories," each holding its own `workshop_average_fares`: same table name, different fully qualified path, no collision.
+
+```mermaid
+flowchart TD
+    M["main"]
+    M --> NA["user_A_namespace/"]
+    M --> NB["user_B_namespace/"]
+    NA --> TA["workshop_average_fares"]
+    NB --> TB["workshop_average_fares"]
+```
+
+## Pipelines
+
+| Pipeline | Source table | Groups by | Computes |
+|---|---|---|---|
+| `user_A_pipeline` | `titanic` | `Pclass` | Mean fare per passenger class |
+| `user_B_pipeline` | `bauplan.taxi_fhvhv` | `hvfhs_license_num` | Mean base fare per license number, for rides from July 2023 onward |
+
+## Usage
+
+```sh
+uv run main.py [OPTIONS]
+```
+
+Run `uv run main.py --help` to see all available options.
+
+### Options
+
+| Option | Default | Description |
+|---|---|---|
+| `--profile` | `default` | Bauplan profile to use. |
+
+### Expected output
+
+```
+=== Scenario #1: no namespace; user B's merge silently overwrites user A's table ===
+
+User A starts working...
+  -> opened branch <USER>.user_A off main
+  -> pipeline succeeded on <USER>.user_A
+  -> user A merged into main; workshop_average_fares is now on main
+
+Schema of workshop_average_fares on main after user A's merge (namespace: bauplan):
+    Pclass                         long
+    Fare                           double
+
+User B starts working (main already contains user A's workshop_average_fares)...
+  -> opened branch <USER>.user_B off main
+  -> pipeline succeeded on <USER>.user_B
+  -> user B merged into main; user A's workshop_average_fares has been silently overwritten
+
+Schema of workshop_average_fares on main after user B's merge (namespace: bauplan):
+    hvfhs_license_num              string
+    base_passenger_fare            double
+
+
+=== Scenario #2: per-user namespaces; both tables coexist on main ===
+
+User A starts working...
+  -> opened branch <USER>.user_A off main
+  -> created namespace user_A_namespace on <USER>.user_A
+  -> pipeline succeeded on <USER>.user_A
+  -> user A merged into main; workshop_average_fares is now on main
+
+Schema of workshop_average_fares on main after user A's merge (namespace: user_A_namespace):
+    Pclass                         long
+    Fare                           double
+
+User B starts working (main already contains user A's workshop_average_fares)...
+  -> opened branch <USER>.user_B off main
+  -> created namespace user_B_namespace on <USER>.user_B
+  -> pipeline succeeded on <USER>.user_B
+  -> user B merged into main; both tables now coexist on main under separate namespaces
+
+Schema of workshop_average_fares on main after user B's merge (namespace: user_B_namespace):
+    hvfhs_license_num              string
+    base_passenger_fare            double
+
+```
+
+## What to observe
+
+- After scenario #1, `workshop_average_fares` on `main` reflects *only* user B's schema; user A's write was silently overwritten. 
+- After scenario #2, both `user_A_namespace.workshop_average_fares` and `user_B_namespace.workshop_average_fares` exist on `main` independently without clash.
+
+## Why this happens
+
+The core idea behind this example is that Bauplan always resolves a "bare" table name to a fully qualified name following the pattern `<namespace>.<table_name>`. Users are not required to specify a namespace explicitly, because it defaults to `bauplan`: a table named `my_table` is `bauplan.my_table` under the hood. That said, users can always override this default by specifying a different namespace, which controls where Bauplan materializes tables and helps avoid naming conflicts.
+
+### Scenario 1
+
+User A branches off `main` where `workshop_average_fares` does not yet exist, writes the table, and merges. No conflict occurs, and the table lands on `main` with user A's schema. User B then branches off `main` *after* user A's merge, so user B's branch already contains user A's table. User B's pipeline writes to the same fully qualified name (default namespace plus `workshop_average_fares`) replacing it on their branch. When user B merges, Bauplan sees an update to an existing table. Bauplan raises no conflict and applies the merge cleanly, so user B's data silently replaces user A's schema and data on `main`. No error appears since this *is* a legitimate merge.
+
+### Scenario 2
+
+Think of a namespace as a directory. When user A creates `user_A_namespace` on their branch and writes `workshop_average_fares` inside it, the merge into `main` carries the namespace over as well: `main` now has a `user_A_namespace/` "directory" containing the table; check our [app](https://app.bauplanlabs.com/catalog/refs/main) to see for yourself. User B does the same with `user_B_namespace`, which lands on `main` as a separate directory.
+
+Both tables share the name `workshop_average_fares`, but their fully qualified names (`user_A_namespace.workshop_average_fares` and `user_B_namespace.workshop_average_fares`) differ, just like two files with the same name can coexist in different directories. From Bauplan's perspective they are entirely distinct tables, so neither merge overwrites the other and both live on `main` side by side. Namespaces are the idiomatic way to let multiple users or pipelines produce independent outputs without stepping on each other.

--- a/examples/learn/07-how-to-manage-conflicts/02_naming_conflict/main.py
+++ b/examples/learn/07-how-to-manage-conflicts/02_naming_conflict/main.py
@@ -1,0 +1,193 @@
+import bauplan
+import typer
+from typing import Annotated
+
+TABLE_NAME = "workshop_average_fares"
+
+
+def run_pipeline(
+    client: bauplan.Client,
+    username: str,
+    main_branch: str,
+    branch: str,
+    pipeline_path: str,
+    namespace: str | None = None,
+) -> str:
+    """
+    Open a fresh workspace for one user and run their pipeline on it.
+
+    Concretely: delete any leftover branch from a previous run, create a new branch off the
+    current state of `main`, optionally create the target namespace on that branch, then run
+    the pipeline. Raises if the job does not succeed. Returns the branch name so the caller
+    can merge it into `main` when the story calls for it.
+    """
+    branch_name = f"{username}.{branch}"
+
+    # Always start from a clean branch so previous runs don't interfere
+    client.delete_branch(branch=branch_name, if_exists=True)
+    client.create_branch(branch=branch_name, from_ref=main_branch, if_not_exists=True)
+    print(f"  -> opened branch {branch_name} off main")
+
+    # Create the user's namespace on the branch (only in the namespaced scenario)
+    if namespace:
+        client.create_namespace(
+            namespace=namespace, branch=branch_name, if_not_exists=True
+        )
+        print(f"  ->  using namespace {namespace} on {branch_name}")
+
+    run_state = client.run(
+        project_dir=pipeline_path, ref=branch_name, namespace=namespace
+    )
+
+    if str(run_state.job_status).lower() != "success":
+        raise Exception(
+            f"{run_state.job_id} failed: {run_state.job_status} - {run_state.error}."
+        )
+    else:
+        print(f"  -> pipeline succeeded on {branch_name}")
+
+    return branch_name
+
+
+def run_scenario(
+    client: bauplan.Client,
+    username: str,
+    main_branch: str,
+    user_A_namespace: str | None,
+    user_B_namespace: str | None,
+):
+    """
+    Play out the naming-conflict story end-to-end, either without or with namespace isolation.
+
+    The two users act sequentially, not concurrently:
+      1. User A opens a fresh branch off main, runs their pipeline, and merges into main.
+         `workshop_average_fares` is now on main (with user A's schema).
+      2. User B then opens their own fresh branch off main (which now already contains
+         user A's table) runs their pipeline, and merges.
+
+    Without namespaces, both users write to the same fully qualified name, so step 2 silently
+    overwrites user A's table on main. With namespaces, each user writes into their own
+    namespace, so both tables coexist on main under different fully qualified names.
+    """
+
+    # --- User A goes first: branch off main, run pipeline, merge back ---
+    # User A produces average Titanic fares grouped by passenger class.
+    print("User A starts working...")
+    user_A_branch = run_pipeline(
+        client=client,
+        username=username,
+        main_branch=main_branch,
+        branch="user_A",
+        pipeline_path="pipelines/user_A_pipeline",
+        namespace=user_A_namespace,
+    )
+
+    client.merge_branch(source_ref=user_A_branch, into_branch=main_branch)
+    print(f"  -> user A merged into main; {TABLE_NAME} is now on main")
+
+    # Inspect what is now on main after user A's merge
+    print()
+    print(
+        f"Schema of {TABLE_NAME} on main after user A's merge (namespace: {user_A_namespace or 'bauplan'}):"
+    )
+    for fields in client.get_table(
+        table=TABLE_NAME, ref=main_branch, namespace=user_A_namespace
+    ).fields:
+        print(f"    {fields.name:<30} {fields.type}")
+    print()
+
+    # --- User B goes second: branch off main (which now already contains user A's table), run, merge back ---
+    # User B produces average NYC taxi fares grouped by license number.
+    print(f"User B starts working (main already contains user A's {TABLE_NAME})...")
+    user_B_branch = run_pipeline(
+        client=client,
+        username=username,
+        main_branch=main_branch,
+        branch="user_B",
+        pipeline_path="pipelines/user_B_pipeline",
+        namespace=user_B_namespace,
+    )
+
+    client.merge_branch(source_ref=user_B_branch, into_branch=main_branch)
+    if user_B_namespace:
+        print(
+            "  -> user B merged into main; both tables now coexist on main under separate namespaces"
+        )
+    else:
+        print(
+            f"  -> user B merged into main; user A's {TABLE_NAME} has been silently overwritten"
+        )
+
+    # Inspect what is on main after user B's merge:
+    #   - without namespaces: user A's table has been silently overwritten by user B's
+    #   - with namespaces: user A's and user B's tables coexist under different namespaces
+    print()
+    print(
+        f"Schema of {TABLE_NAME} on main after user B's merge (namespace: {user_B_namespace or 'bauplan'}):"
+    )
+    for fields in client.get_table(
+        table=TABLE_NAME, ref=main_branch, namespace=user_B_namespace
+    ).fields:
+        print(f"    {fields.name:<30} {fields.type}")
+    print()
+
+
+def main(
+    profile: Annotated[str, typer.Option(help="Bauplan profile to use")] = "default",
+) -> None:
+    """
+    Demonstrate the naming conflict problem and one way to resolve it with namespaces.
+
+    The script plays two scenarios back to back, each one a full story where user A merges
+    first and user B merges second on top of user A's result:
+
+      - Scenario #1 (no namespace): both users write 'workshop_average_fares' in the default
+        namespace. Both merges succeed, but user B silently overwrites user A's table on main;
+        the schema and data from user A are lost.
+      - Scenario #2 (user namespaces): each user writes to their own namespace, so both tables
+        coexist on main under 'user_A_namespace' and 'user_B_namespace' respectively.
+
+    The table is wiped from main before the scenarios run so the demo always starts from a
+    clean state.
+    """
+    client = bauplan.Client(profile=profile)
+
+    username = client.info().user.username
+
+    # Use a "fake" main branch to avoid polluting main
+    example_main_branch = f"{username}.main"
+    client.delete_branch(branch=example_main_branch, if_exists=True)
+    client.create_branch(
+        branch=example_main_branch, from_ref="main", if_not_exists=True
+    )
+
+    # Reset the target table on main so the conflict is reproducible across runs
+    client.delete_table(table=TABLE_NAME, branch=example_main_branch, if_exists=True)
+
+    print(
+        "\n=== Scenario #1: no namespace; user B's merge silently overwrites user A's table ===\n"
+    )
+
+    # In scenario #1, these will be set to None and Bauplan will resort to the default namespace, i.e. 'bauplan'
+    run_scenario(
+        client=client,
+        username=username,
+        main_branch=example_main_branch,
+        user_A_namespace=None,
+        user_B_namespace=None,
+    )
+
+    print("\n=== Scenario #2: per-user namespaces; both tables coexist on main ===\n")
+
+    # In scenario #2, the namespaces are instead specified, avoiding naming conflict
+    run_scenario(
+        client=client,
+        username=username,
+        main_branch=example_main_branch,
+        user_A_namespace="user_A_namespace",
+        user_B_namespace="user_B_namespace",
+    )
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/examples/learn/07-how-to-manage-conflicts/02_naming_conflict/pipelines/user_A_pipeline/bauplan_project.yaml
+++ b/examples/learn/07-how-to-manage-conflicts/02_naming_conflict/pipelines/user_A_pipeline/bauplan_project.yaml
@@ -1,0 +1,3 @@
+project:
+  id: 20af3fc0-3164-46dc-acd3-279ccc356a3a
+  name: user_A_pipeline

--- a/examples/learn/07-how-to-manage-conflicts/02_naming_conflict/pipelines/user_A_pipeline/models.py
+++ b/examples/learn/07-how-to-manage-conflicts/02_naming_conflict/pipelines/user_A_pipeline/models.py
@@ -1,0 +1,14 @@
+import bauplan
+
+
+@bauplan.python("3.12", pip={"polars": "1.37"})
+@bauplan.model(materialization_strategy="REPLACE")
+def workshop_average_fares(
+    data=bauplan.Model("bauplan.titanic", columns=["Pclass", "Fare"]),
+):
+    """Compute the mean Titanic fare for each passenger class."""
+    import polars as pl
+
+    df = pl.from_arrow(data)
+
+    return df.group_by(pl.col("Pclass")).agg(pl.col("Fare").mean()).to_arrow()

--- a/examples/learn/07-how-to-manage-conflicts/02_naming_conflict/pipelines/user_A_pipeline/pyproject.toml
+++ b/examples/learn/07-how-to-manage-conflicts/02_naming_conflict/pipelines/user_A_pipeline/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "user_A_pipeline"
+requires-python = "~=3.12"
+dependencies = ["bauplan~=0.1.9"]

--- a/examples/learn/07-how-to-manage-conflicts/02_naming_conflict/pipelines/user_B_pipeline/bauplan_project.yaml
+++ b/examples/learn/07-how-to-manage-conflicts/02_naming_conflict/pipelines/user_B_pipeline/bauplan_project.yaml
@@ -1,0 +1,3 @@
+project:
+  id: 25ab33ed-ab5b-4725-b6be-1a214f746bc2
+  name: user_B_pipeline

--- a/examples/learn/07-how-to-manage-conflicts/02_naming_conflict/pipelines/user_B_pipeline/models.py
+++ b/examples/learn/07-how-to-manage-conflicts/02_naming_conflict/pipelines/user_B_pipeline/models.py
@@ -1,0 +1,22 @@
+import bauplan
+
+
+@bauplan.python("3.12", pip={"polars": "1.37"})
+@bauplan.model(materialization_strategy="REPLACE")
+def workshop_average_fares(
+    data=bauplan.Model(
+        "bauplan.taxi_fhvhv",
+        columns=["hvfhs_license_num", "base_passenger_fare", "on_scene_datetime"],
+        filter="on_scene_datetime >= '2023-07-01'",
+    ),
+):
+    """Compute the mean base passenger fare for each HVFHV license number, filtered to rides from July 2023 onwards."""
+    import polars as pl
+
+    df = pl.from_arrow(data)
+
+    return (
+        df.group_by(pl.col("hvfhs_license_num"))
+        .agg(pl.col("base_passenger_fare").mean())
+        .to_arrow()
+    )

--- a/examples/learn/07-how-to-manage-conflicts/02_naming_conflict/pipelines/user_B_pipeline/pyproject.toml
+++ b/examples/learn/07-how-to-manage-conflicts/02_naming_conflict/pipelines/user_B_pipeline/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "user_B_pipeline"
+requires-python = "~=3.12"
+dependencies = ["bauplan~=0.1.9"]

--- a/examples/learn/07-how-to-manage-conflicts/03_schema_conflict/README.md
+++ b/examples/learn/07-how-to-manage-conflicts/03_schema_conflict/README.md
@@ -1,0 +1,72 @@
+# Schema conflict
+
+Demonstrates how a Bauplan expectation catches a subtle schema drift between two versions of the same pipeline and prevents the drift.
+
+A first, coarse pipeline runs: it computes the mean Titanic fare per passenger class with `Fare` as `Float32`, and carries an expectation that `Fare` must stay `Float32` since downstream dashboards rely on the type. A second, finer-grained pipeline then builds on this to add more detail, grouping by `Pclass` and `Sex` and adding a passenger count. While rewriting, `Fare` accidentally gets cast to `Float64`. Both pipelines run sequentially on the same branch with strict mode on. The expectation fires on the new output, halts the run, and no drift happens.
+
+## Scenario
+
+```mermaid
+gitGraph
+   commit id: "main: no workshop_average_fares"
+   branch schema_conflict
+   checkout schema_conflict
+   commit id: "old_pipeline: Fare Float32, expectation OK"
+   commit id: "new_pipeline: Fare Float64, expectation FAIL"
+   checkout main
+```
+
+## Pipelines
+
+| Pipeline | Source table | Groups by | Output columns | Fare type |
+|---|---|---|---|---|
+| `old_pipeline` | `bauplan.titanic` | `Pclass` | `Pclass`, `Fare` | `Float32` |
+| `new_pipeline` | `bauplan.titanic` | `Pclass`, `Sex` | `Pclass`, `Sex`, `Fare`, `n_passengers` | `Float64` (drift) |
+
+Both pipelines ship the same expectation: `Fare` must be `Float32`.
+
+## Usage
+
+```sh
+uv run main.py [OPTIONS]
+```
+
+Run `uv run main.py --help` to see all available options.
+
+### Options
+
+| Option | Default | Description |
+|---|---|---|
+| `--profile` | `default` | Bauplan profile to use. |
+
+### Expected output
+
+```
+=== Step 1: ship the old pipeline (mean fare per Pclass, Fare: Float32) ===
+
+Old pipeline succeeded; expectation passed (Fare is Float32)
+workshop_average_fares is now published
+
+Schema of workshop_average_fares:
+    Pclass               long
+    Fare                 float
+
+=== Step 2: build the new pipeline (adds Sex, n_passengers; subtle Fare drift) ===
+
+Running the new pipeline...
+New pipeline run blocked by the expectation, as expected. Status: JobStatus.failed. Reason: ...
+
+Schema of workshop_average_fares after the new pipeline was blocked:
+    Pclass               long
+    Fare                 float
+```
+
+## What to observe
+
+After the old pipeline runs, `workshop_average_fares` on the branch has `Fare: Float32`. The new pipeline fails on the expectation and Bauplan attempts no merge, not even on the current branch. The transactional branch catches the subtle Float32 → Float64 drift in the new pipeline before it spreads.
+
+## Why this matters
+
+Schema drift rarely arrives as an obvious break. It slips in as a one-token change (in this case, `pl.Float32` becomes `float`, possibly because different engineers implemented it differently) and the pipeline still "works." The output table is still there. Row counts are still right. What changes is the contract with whoever reads the table, and that break surfaces far from where someone introduced it: a dashboard that truncates cents, a join that silently drops rows because the types no longer match, a model that loses precision. Expectations turn that implicit contract into executable code that lives next to the model. 
+
+Because the expectation is part of the pipeline DAG and the pipeline runs with `strict="on"`, it fires automatically after the model materializes and fails the run before the branch reaches a mergeable state.

--- a/examples/learn/07-how-to-manage-conflicts/03_schema_conflict/main.py
+++ b/examples/learn/07-how-to-manage-conflicts/03_schema_conflict/main.py
@@ -1,0 +1,102 @@
+import bauplan
+import typer
+from typing import Annotated
+
+TABLE_NAME = "workshop_average_fares"
+
+
+def print_schema(client: bauplan.Client, ref: str) -> None:
+    """Print the schema of the target table at `ref`."""
+    for field in client.get_table(table=TABLE_NAME, ref=ref).fields:
+        print(f"    {field.name:<20} {field.type}")
+
+
+def main(
+    profile: Annotated[str, typer.Option(help="Bauplan profile to use")] = "default",
+) -> None:
+    """
+    Demonstrate how a Bauplan expectation catches a subtle schema drift between two
+    versions of the same pipeline and prevents the drift.
+
+    Both pipelines run sequentially on the same branch with strict mode enabled.
+    In order:
+      1. The old pipeline runs on the branch. It computes the mean Titanic fare per
+         passenger class, with `Fare` cast to Float32. An expectation that ships with
+         the pipeline asserts `Fare` must be Float32: downstream dashboards rely on
+         that type. The run succeeds.
+      2. The business asks for a finer-grained view: group by `Pclass` AND `Sex`, and
+         include the number of passengers. A new pipeline is built for that.
+      3. A subtle change slips in while rewriting: `Fare` is cast with Python's `float`
+         (Float64 in polars) instead of `pl.Float32`.
+      4. The new pipeline runs on the same branch. The expectation fires on the new
+         output, the run fails, and no drift happens on the branch.
+    """
+    client = bauplan.Client(profile=profile)
+
+    username = client.info().user.username
+    branch = f"{username}.schema_conflict"
+
+    # Start from fresh branch so previous runs don't interfere
+    client.delete_branch(branch=branch, if_exists=True)
+    client.create_branch(branch=branch, from_ref="main")
+
+    # --- Step 1: ship the old pipeline ---
+    print(
+        "\n=== Step 1: ship the old pipeline (mean fare per Pclass, Fare: Float32) ===\n"
+    )
+
+    # Setting strict="on" tells Bauplan to run the expectations associated with the DAG,
+    # which prevents tables that fail validation from being merged.
+    run_state = client.run(
+        project_dir="pipelines/old_pipeline", ref=branch, strict="on"
+    )
+
+    if str(run_state.job_status).lower() != "success":
+        raise Exception(
+            f"Old pipeline failed unexpectedly: {run_state.job_status} - {run_state.error}"
+        )
+    print("Old pipeline succeeded; expectation passed (Fare is Float32)")
+    print(f"{TABLE_NAME} is now published")
+    assert client.has_table(table=TABLE_NAME, ref=branch)
+
+    print(f"\nSchema of {TABLE_NAME}:")
+    print_schema(client, ref=branch)
+
+    # --- Step 2: run the new pipeline; the expectation catches the type drift ---
+    # `cast(float)` inside the new pipeline promotes Fare to Float64 (polars' default
+    # for Python's `float`). The pipeline still carries the expectation that Fare must
+    # be Float32, so it fires after the model materializes and fails the run.
+    print(
+        "\n=== Step 2: build the new pipeline (adds Sex, n_passengers; subtle Fare drift) ===\n"
+    )
+
+    print("Running the new pipeline...")
+    run_state = client.run(
+        project_dir="pipelines/new_pipeline", ref=branch, strict="on"
+    )
+
+    if str(run_state.job_status).lower() == "success":
+        # Should not happen given the drift above; keep the guard so a regression is loud.
+        print("New pipeline succeeded (unexpected: the drift slipped through)")
+    else:
+        # Expected outcome: the expectation halted the run before anyone could merge.
+        print(
+            f"New pipeline run blocked by the expectation, as expected. "
+            f"Status: {run_state.job_status}. "
+            f"Reason: {run_state.error}."
+        )
+
+    # --- Step 3: because the run failed, we never attempt a merge; main is intact ---
+    # Conditioning the merge on run success is what turns the failed expectation into
+    # a blocked merge. No try/except around merge_branch is needed because we simply
+    # never call it when the run does not succeed.
+    print(f"\nSchema of {TABLE_NAME} after the new pipeline was blocked:")
+    print_schema(client, ref=branch)
+    print()
+
+    # Cleanup afterwards
+    client.delete_branch(branch=branch, if_exists=True)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/examples/learn/07-how-to-manage-conflicts/03_schema_conflict/pipelines/new_pipeline/bauplan_project.yaml
+++ b/examples/learn/07-how-to-manage-conflicts/03_schema_conflict/pipelines/new_pipeline/bauplan_project.yaml
@@ -1,0 +1,3 @@
+project:
+  id: 25561bd7-6497-4ed9-bb0d-f0f6d89200bc
+  name: new_pipeline

--- a/examples/learn/07-how-to-manage-conflicts/03_schema_conflict/pipelines/new_pipeline/models.py
+++ b/examples/learn/07-how-to-manage-conflicts/03_schema_conflict/pipelines/new_pipeline/models.py
@@ -1,0 +1,32 @@
+import bauplan
+
+
+@bauplan.python("3.12", pip={"polars": "1.37"})
+@bauplan.model(materialization_strategy="REPLACE")
+def workshop_average_fares(
+    data=bauplan.Model("bauplan.titanic", columns=["Pclass", "Fare", "Sex"]),
+):
+    """Compute the mean Titanic fare for each passenger class."""
+    import polars as pl
+
+    df = pl.from_arrow(data)
+
+    return (
+        df.group_by(pl.col("Pclass"), pl.col("Sex"))
+        .agg(pl.col("Fare").mean().cast(float), pl.len().alias("n_passengers"))
+        .to_arrow()
+    )
+
+
+@bauplan.expectation()
+@bauplan.python("3.12", pip={"pyarrow": "23.0"})
+def test_fare(data=bauplan.Model("workshop_average_fares", columns=["Fare"])):
+    """Validates that the Fare is a float"""
+
+    import pyarrow as pa
+
+    is_valid = data.schema.field("Fare").type == pa.float32()
+    assert is_valid, (
+        f"Fare column has the wrong type. Expected {pa.float32()}, found {data.schema.field('Fare').type}"
+    )
+    return is_valid

--- a/examples/learn/07-how-to-manage-conflicts/03_schema_conflict/pipelines/new_pipeline/pyproject.toml
+++ b/examples/learn/07-how-to-manage-conflicts/03_schema_conflict/pipelines/new_pipeline/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "new_pipeline"
+requires-python = "~=3.12"
+dependencies = ["bauplan~=0.1.10"]

--- a/examples/learn/07-how-to-manage-conflicts/03_schema_conflict/pipelines/old_pipeline/bauplan_project.yaml
+++ b/examples/learn/07-how-to-manage-conflicts/03_schema_conflict/pipelines/old_pipeline/bauplan_project.yaml
@@ -1,0 +1,3 @@
+project:
+  id: adb01952-77a0-4c37-bd8a-5f6940f35c92
+  name: old_pipeline

--- a/examples/learn/07-how-to-manage-conflicts/03_schema_conflict/pipelines/old_pipeline/models.py
+++ b/examples/learn/07-how-to-manage-conflicts/03_schema_conflict/pipelines/old_pipeline/models.py
@@ -1,0 +1,32 @@
+import bauplan
+
+
+@bauplan.python("3.12", pip={"polars": "1.37"})
+@bauplan.model(materialization_strategy="REPLACE")
+def workshop_average_fares(
+    data=bauplan.Model("bauplan.titanic", columns=["Pclass", "Fare"]),
+):
+    """Compute the mean Titanic fare for each passenger class."""
+    import polars as pl
+
+    df = pl.from_arrow(data)
+
+    return (
+        df.group_by(pl.col("Pclass"))
+        .agg(pl.col("Fare").mean().cast(pl.Float32))
+        .to_arrow()
+    )
+
+
+@bauplan.expectation()
+@bauplan.python("3.12", pip={"pyarrow": "23.0"})
+def test_fare(data=bauplan.Model("workshop_average_fares", columns=["Fare"])):
+    """Validates that the Fare is a float"""
+
+    import pyarrow as pa
+
+    is_valid = data.schema.field("Fare").type == pa.float32()
+    assert is_valid, (
+        f"Fare column has the wrong type. Expected {pa.float32()}, found {data.schema.field('Fare').type}"
+    )
+    return is_valid

--- a/examples/learn/07-how-to-manage-conflicts/03_schema_conflict/pipelines/old_pipeline/pyproject.toml
+++ b/examples/learn/07-how-to-manage-conflicts/03_schema_conflict/pipelines/old_pipeline/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "old_pipeline"
+requires-python = "~=3.12"
+dependencies = ["bauplan~=0.1.10"]

--- a/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/README.md
+++ b/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/README.md
@@ -1,0 +1,96 @@
+# Reprocessing race conflict
+
+Demonstrates how to fix and backfill a corrupted table.
+
+A scheduled job appends inflation-adjusted fares year-by-year to a shared fare table. The update pipeline carries a bug, a missing `+ 1.0` in the exponentiation, that causes fares to collapse toward zero instead of growing. When you discover the bug, you must revert the table to the initial 1912 snapshot, replay every past year with the correct formula, and merge the corrected table back into the user branch.
+
+## Scenario
+
+```mermaid
+gitGraph
+   commit id: "1912 - correct"
+   commit id: "1913 - wrong"
+   commit id: "1914 - wrong"
+   branch fix_branch
+   checkout fix_branch
+   commit id: "revert to 1912"
+   commit id: "1913 - fixed"
+   commit id: "1914 - fixed"
+   checkout main
+   merge fix_branch id: "merge fixed"
+```
+
+
+## Pipelines
+
+| Pipeline | Strategy | Purpose |
+|---|---|---|
+| `setup_table` | `REPLACE` | Creates the initial fare snapshot at the 1912 baseline |
+| `update_table_wrong` | `APPEND` | Appends yearly fares with the buggy inflation formula |
+| `update_table_fixed` | `APPEND` | Appends yearly fares with the correct inflation formula |
+
+## Usage
+
+```sh
+uv run main.py [OPTIONS]
+```
+
+Run `uv run main.py --help` to see all available options.
+
+### Options
+
+| Option | Default | Description |
+|---|---|---|
+| `--profile` | `default` | Bauplan profile to use. |
+
+### Expected output
+
+```
+Working on branch: <USER>.reprocessing_race_main
+
+=== Step 1: initialise 'workshop_fare_table' at the 1912 baseline ===
+
+Initial state available at: <USER>.reprocessing_race_main@9aa233041c2ab884b440d3798a11e41dd71e16036271d0aae5c4abeabd34b039
+
+=== Step 2: append 1913-1914 with the buggy formula ===
+
+[1913] Appended with wrong inflation formula.
+  avg fare by year:
+    1912: $32.2042
+    1913: $6.4408
+[1914] Appended with wrong inflation formula.
+  avg fare by year:
+    1912: $32.2042
+    1913: $6.4408
+    1914: $1.2882
+
+[!!!] Bug discovered: inflation formula is missing '+ 1.0', fares are collapsing instead of growing.
+
+[fix] Starting fix and backfill in background...
+  [fix] Table reverted to initial snapshot (<USER>.reprocessing_race_main@9aa233041c2ab884b440d3798a11e41dd71e16036271d0aae5c4abeabd34b039)
+  [fix] Backfilling 1913-1914 with correct formula...
+  [fix] Backfilled 1913
+  [fix] Backfilled 1914
+[fix] Fixed table merged back into main branch.
+
+
+=== Final state of 'workshop_fare_table' on <USER>.reprocessing_race_main ===
+
+  avg fare by year:
+    1912: $32.2042
+    1913: $38.6450
+    1914: $46.3741
+```
+
+## What to observe
+
+- After step 2, fares collapse year-on-year. The bug is obvious from the numbers themselves, not from any exception.
+- The backfill runs entirely on `fix_branch` and is only swapped back in via a single merge at the end. From the scheduler perspective, the table "changes" exactly once, atomically.
+
+## Why this matters
+
+In production, a pipeline like "append a yearly slice to a fare table" is almost always owned by a scheduler such as Airflow, cron, or Prefect. When you find a bug in historical rows, Bauplan's Git-like branching makes it possible to revert back to the original, uncorrupted state, replay the historical data with the now-fixed pipeline, and finally update the lake with the amended version of the data.
+
+This example is admittedly a somewhat academic scenario, but it illustrates cleanly how branching gives you a safe surface to perform historical corrections without touching production data until you are confident the fix is right.
+
+It is worth being explicit about when this flow can break down. The approach assumes that no concurrent writers have modified the underlying table between the moment you branch off and the moment you merge back. In practice, if other pipelines are appending to or modifying that same table while your recovery branch is in flight, merging back may produce conflicts.

--- a/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/main.py
+++ b/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/main.py
@@ -1,0 +1,160 @@
+import bauplan
+import typer
+from typing import Annotated
+
+TABLE_NAME = "workshop_fare_table"
+
+
+def run_pipeline(
+    client: bauplan.Client, branch: str, pipeline_path: str, parameters: dict = None
+) -> None:
+    """Run a Bauplan pipeline on `branch` and raise if the job does not succeed."""
+    run_state = client.run(project_dir=pipeline_path, ref=branch, parameters=parameters)
+
+    if str(run_state.job_status).lower() != "success":
+        raise Exception(
+            f"{run_state.job_id} failed: {run_state.job_status} - {run_state.error}."
+        )
+
+
+def print_avg_fare_by_year(client: bauplan.Client, ref: str) -> None:
+    """
+    Print the average fare per year on `ref` in ascending year order.
+    """
+    result = client.query(
+        f"SELECT fare_calculated_in, ROUND(AVG(Fare), 4) AS avg_fare "
+        f"FROM {TABLE_NAME} "
+        f"GROUP BY fare_calculated_in "
+        f"ORDER BY fare_calculated_in",
+        ref=ref,
+    )
+
+    years = result.column("fare_calculated_in").to_pylist()
+    fares = result.column("avg_fare").to_pylist()
+    print("  avg fare by year:")
+    for year, fare in zip(years, fares):
+        print(f"    {year}: ${fare:.4f}")
+
+
+def fix_and_backfill(
+    client: bauplan.Client,
+    init_ref: str,
+    main_branch: str,
+    fix_branch: str,
+) -> None:
+    """
+    Revert the fare table to its pre-inflation snapshot on an isolated `fix_branch`,
+    then re-run the correct pipeline for 1913 and 1914.
+
+    This is the remediation step once the bug is discovered: the corrupted history is
+    rolled back and rebuilt year-by-year with the fixed formula.
+    """
+    client.delete_branch(branch=fix_branch, if_exists=True)
+    client.create_branch(branch=fix_branch, from_ref=main_branch, if_not_exists=True)
+
+    client.revert_table(
+        table=TABLE_NAME,
+        source_ref=init_ref,
+        into_branch=fix_branch,
+        replace=True,
+    )
+    print(f"  [fix] Table reverted to initial snapshot ({init_ref})")
+
+    print("  [fix] Backfilling 1913-1914 with correct formula...")
+    for year in [1913, 1914]:
+        run_pipeline(
+            client=client,
+            branch=fix_branch,
+            pipeline_path="pipelines/update_table_fixed",
+            parameters={"year": year},
+        )
+        print(f"  [fix] Backfilled {year}")
+
+def main(
+    profile: Annotated[str, typer.Option(help="Bauplan profile to use")] = "default",
+) -> None:
+    """
+    Demonstrate how to fix and backfill a corrupted table.
+
+    The scenario is a scheduled job that appends inflation-adjusted fares year-by-year
+    to a shared table. The update pipeline carries a bug (a missing '+ 1.0' in the
+    exponentiation) that causes fares to collapse toward zero. When the bug is found,
+    we must repair the historical rows.
+
+      1. Build the initial fare table at the 1912 baseline.
+      2. The scheduler runs: it appends 1913-1914 data with the buggy formula. Fares
+         collapse instead of growing.
+      3. On 1914, the bug is spotted. Kick off a fix-and-backfill on an isolated branch:
+         revert to the 1912 snapshot, replay every past year with the correct formula,
+         then merge the corrected table back into the main.
+
+    """
+    client = bauplan.Client(profile=profile)
+
+    username = client.info().user.username
+
+    # Set up branches
+    main_branch = f"{username}.reprocessing_race_main"
+    fix_branch = f"{username}.reprocessing_race_fix"
+
+    # Start from fresh branches so previous runs don't interfere
+    for b in (main_branch, fix_branch):
+        client.delete_branch(branch=b, if_exists=True)
+
+    # Start by creating a (fake) main branch
+    client.create_branch(branch=main_branch, from_ref="main", if_not_exists=True)
+    print(f"Working on branch: {main_branch}")
+
+    # --- Step 1: build the initial fare table at the 1912 baseline ---
+    print(f"\n=== Step 1: initialise '{TABLE_NAME}' at the 1912 baseline ===\n")
+    run_pipeline(
+        client=client, branch=main_branch, pipeline_path="pipelines/setup_table"
+    )
+
+    # Snapshot the current hash so the fix can revert the table to exactly this state,
+    # regardless of any commits that land on main_branch in the meantime.
+    init_hash = client.get_branch(main_branch).hash
+    init_ref = f"{main_branch}@{init_hash}"
+    print(f"Initial state available at: {init_ref}")
+
+    # --- Step 2: append years using the wrong formula ---
+    print("\n=== Step 2: append 1913-1914 with the buggy formula ===\n")
+
+    for year in [1913, 1914]:
+        # Append inflation-adjusted fares using the wrong formula
+        run_pipeline(
+            client=client,
+            branch=main_branch,
+            pipeline_path="pipelines/update_table_wrong",
+            parameters={"year": year},
+        )
+        print(f"[{year}] Appended with wrong inflation formula.")
+        print_avg_fare_by_year(client=client, ref=main_branch)
+
+    # --- Step 3: bug spotted; fix-and-backfill ---
+    print(
+        "\n[!!!] Bug discovered: inflation formula is missing "
+        "'+ 1.0', fares are collapsing instead of growing."
+    )
+
+    print("\n[fix] Starting fix and backfill in background...")
+
+    fix_and_backfill(
+        client=client,
+        init_ref=init_ref,
+        main_branch=main_branch,
+        fix_branch=fix_branch,
+    )
+    client.merge_branch(source_ref=fix_branch, into_branch=main_branch)
+    print("[fix] Fixed table merged back into main branch.\n")
+
+    print(f"\n=== Final state of '{TABLE_NAME}' on {main_branch} ===\n")
+    print_avg_fare_by_year(client=client, ref=main_branch)
+
+    # Cleanup afterwards
+    for b in (main_branch, fix_branch):
+        client.delete_branch(branch=b, if_exists=True)
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/setup_table/bauplan_project.yaml
+++ b/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/setup_table/bauplan_project.yaml
@@ -1,0 +1,3 @@
+project:
+  id: a4025276-30ec-498d-8795-b30ce27214a0
+  name: setup_table

--- a/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/setup_table/models.py
+++ b/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/setup_table/models.py
@@ -1,0 +1,36 @@
+import bauplan
+
+
+@bauplan.python("3.12", pip={"polars": "1.37"})
+@bauplan.model(materialization_strategy="REPLACE")
+def workshop_fare_table(
+    workshop_passengers_fare=bauplan.Model(
+        "titanic",
+        columns=["Name", "Fare"],
+    ),
+):
+    """
+    Find fare for each passenger.
+
+    Returned table:
+    | Name                        | Fare  | fare_calculated_in |
+    |-----------------------------|------|-------------------|
+    | Braund, Mr. Owen Harris     | 7.25 | 1912              |
+    | Heikkinen, Miss. Laina      | 26.0 | 1912              |
+    | Allen, Mr. William Henry    | 13.88 | 1912              |
+    | McCarthy, Mr. Timothy J     | 54.0 | 1912              |
+
+    """
+    import polars as pl
+
+    return (
+        pl.from_arrow(workshop_passengers_fare)
+        .select("Name", "Fare")
+        .sort("Name")
+        .with_columns(
+            fare_calculated_in=pl.lit(
+                1912
+            )  # Their fare was computed in 1912, we will adjust for inflation
+        )
+        .to_arrow()
+    )

--- a/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/setup_table/pyproject.toml
+++ b/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/setup_table/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "setup_table"
+requires-python = "~=3.12"
+dependencies = ["bauplan~=0.1.9"]

--- a/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/update_table_fixed/bauplan_project.yaml
+++ b/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/update_table_fixed/bauplan_project.yaml
@@ -1,0 +1,14 @@
+project:
+  id: ef737fb6-e5fc-4451-bbe2-b3e4d21175a3
+  name: update_table_fixed
+parameters:
+  year:
+    type: int
+    default: 1912
+    description: "Year at which new fare is computed, adjusted to inflation"
+    required: true
+  inflation_rate:
+    type: float
+    default: 0.2
+    description: "(Flat) inflation rate"
+    required: true

--- a/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/update_table_fixed/models.py
+++ b/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/update_table_fixed/models.py
@@ -1,0 +1,37 @@
+import bauplan
+
+
+@bauplan.python("3.12", pip={"polars": "1.37"})
+@bauplan.model(materialization_strategy="APPEND")
+def workshop_fare_table(
+    passengers_fare=bauplan.Model(
+        "titanic",
+        columns=["Name", "Fare"],
+    ),
+    year=bauplan.Parameter("year"),
+    inflation_rate=bauplan.Parameter("inflation_rate"),
+):
+    """
+    Append inflation-adjusted fares for the given year using the correct formula.
+
+    The inflation multiplier is (inflation_rate + 1.0)^(year - 1912), which correctly
+    compounds the rate over time and causes fares to grow year-on-year.
+    """
+    import polars as pl
+
+    return (
+        pl.from_arrow(passengers_fare)
+        .with_columns(
+            Fare=pl.col("Fare")
+            * pl.lit(
+                (
+                    float(inflation_rate)
+                    # Reinstating the 1.0 to fix the calculation
+                    + 1.0
+                )
+            ).pow(year - 1912),
+            fare_calculated_in=pl.lit(int(year)),
+        )
+        .sort("Name")
+        .to_arrow()
+    )

--- a/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/update_table_fixed/pyproject.toml
+++ b/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/update_table_fixed/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "update_table_fixed"
+requires-python = "~=3.12"
+dependencies = ["bauplan~=0.1.9"]

--- a/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/update_table_wrong/bauplan_project.yaml
+++ b/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/update_table_wrong/bauplan_project.yaml
@@ -1,0 +1,14 @@
+project:
+  id: 44a8ca27-9bf5-440f-9d3c-fc9934708bdc
+  name: update_table_wrong
+parameters:
+  year:
+    type: int
+    default: 1912
+    description: "Year at which new fare is computed, adjusted to inflation"
+    required: true
+  inflation_rate:
+    type: float
+    default: 0.2
+    description: "(Flat) inflation rate"
+    required: true

--- a/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/update_table_wrong/models.py
+++ b/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/update_table_wrong/models.py
@@ -1,0 +1,38 @@
+import bauplan
+
+
+@bauplan.python("3.12", pip={"polars": "1.37"})
+@bauplan.model(materialization_strategy="APPEND")
+def workshop_fare_table(
+    passengers_fare=bauplan.Model(
+        "titanic",
+        columns=["Name", "Fare"],
+    ),
+    year=bauplan.Parameter("year"),
+    inflation_rate=bauplan.Parameter("inflation_rate"),
+):
+    """
+    Append inflation-adjusted fares for the given year using a buggy formula.
+
+    The inflation multiplier is computed as inflation_rate^(year - 1912) rather than
+    (inflation_rate + 1.0)^(year - 1912). Because inflation_rate is a small decimal,
+    raising it to increasing powers drives fares toward zero instead of growing them.
+    """
+    import polars as pl
+
+    return (
+        pl.from_arrow(passengers_fare)
+        .with_columns(
+            Fare=pl.col("Fare")
+            * pl.lit(
+                (
+                    float(inflation_rate)
+                    # Removing 1.0 obviously tanks the fare
+                    # + 1.0
+                )
+            ).pow(year - 1912),
+            fare_calculated_in=pl.lit(int(year)),
+        )
+        .sort("Name")
+        .to_arrow()
+    )

--- a/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/update_table_wrong/pyproject.toml
+++ b/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/pipelines/update_table_wrong/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "update_table_wrong"
+requires-python = "~=3.12"
+dependencies = ["bauplan~=0.1.9"]

--- a/examples/learn/07-how-to-manage-conflicts/README.md
+++ b/examples/learn/07-how-to-manage-conflicts/README.md
@@ -1,0 +1,26 @@
+# Conflicts in Bauplan
+
+A collection of self-contained examples that show how Bauplan's Git-like branching handles common data engineering problems such as conflicts, corruption, and lakehouse hygiene.
+
+Each example lives in its own directory with a `main.py` entry point and a `README.md` that explains its aim, the expected output, and why the behaviour matters.
+
+## Examples
+
+| # | Directory | What it shows |
+|---|---|---|
+| 01 | `01_concurrency_conflict` | Two users independently create the same table; Bauplan rejects the second merge |
+| 02 | `02_naming_conflict` | Two pipelines write to the same table name; silent overwrite vs. namespace isolation |
+| 03 | `03_schema_conflict` | An expectation catches a subtle type drift before it can reach the branch |
+| 04 | `04_corruption_conflict` | A corrupted table must revert to a healthy state and be repopulated |
+
+## Running an example
+
+Every example uses `uv` for dependency management. From the example directory:
+
+```sh
+uv run main.py
+# or, to pick a non-default Bauplan profile:
+uv run main.py --profile <profile>
+```
+
+Run `uv run main.py --help` in any directory to see all available options.

--- a/examples/learn/07-how-to-manage-conflicts/pyproject.toml
+++ b/examples/learn/07-how-to-manage-conflicts/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "07-how-to-manage-conflicts"
+version = "1.0.0"
+description = "Examples of how to manage conflicts in Bauplan"
+readme = "README.md"
+requires-python = "==3.13.*"
+dependencies = [
+    "bauplan~=0.1.10",
+    "typer~=0.24.1",
+]

--- a/examples/learn/07-how-to-manage-conflicts/uv.lock
+++ b/examples/learn/07-how-to-manage-conflicts/uv.lock
@@ -1,0 +1,150 @@
+version = 1
+revision = 3
+requires-python = "==3.13.*"
+
+[[package]]
+name = "07-how-to-manage-conflicts"
+version = "1.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "bauplan" },
+    { name = "typer" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "bauplan", specifier = "~=0.1.10" },
+    { name = "typer", specifier = "~=0.24.1" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "bauplan"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyarrow" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/b4/c30097c3838d3ebaa2efbfe0236061586429592158a0d230542467222a1f/bauplan-0.1.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4a9f64849227ca31f3a51e374303c73687ae9d5139764432f60e96c9296670bf", size = 16195221, upload-time = "2026-04-07T14:35:45.254Z" },
+    { url = "https://files.pythonhosted.org/packages/89/32/30ba3e92364ec1ed6ff9fddb0b30faa7eabea5344069d838acbfea707c39/bauplan-0.1.10-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:e46c3e702b8643eeb5b57c4540bdbd55a7fabf5ed86812a1909ec01c8f1e7f25", size = 16899059, upload-time = "2026-04-07T14:36:01.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/03/9fa03c21d081c18cdb2491b7422356c16eb9eccc01ce4ac50c57da44b4a0/bauplan-0.1.10-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:bc56325d7b6aeb149053c813cab74efb7a6da39330c56d0ee9f4688982785d21", size = 19166755, upload-time = "2026-04-07T14:35:52.198Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "23.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/10/2cbe4c6f0fb83d2de37249567373d64327a5e4d8db72f486db42875b08f6/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8", size = 34210066, upload-time = "2026-02-16T10:10:45.487Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/4f/679fa7e84dadbaca7a65f7cdba8d6c83febbd93ca12fa4adf40ba3b6362b/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f", size = 35825526, upload-time = "2026-02-16T10:10:52.266Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/63/d2747d930882c9d661e9398eefc54f15696547b8983aaaf11d4a2e8b5426/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677", size = 44473279, upload-time = "2026-02-16T10:11:01.557Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2", size = 47585798, upload-time = "2026-02-16T10:11:09.401Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/476943001c54ef078dbf9542280e22741219a184a0632862bca4feccd666/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37", size = 48179446, upload-time = "2026-02-16T10:11:17.781Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b6/5dd0c47b335fcd8edba9bfab78ad961bd0fd55ebe53468cc393f45e0be60/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2", size = 50623972, upload-time = "2026-02-16T10:11:26.185Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/09/a532297c9591a727d67760e2e756b83905dd89adb365a7f6e9c72578bcc1/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a", size = 27540749, upload-time = "2026-02-16T10:12:23.297Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8e/38749c4b1303e6ae76b3c80618f84861ae0c55dd3c2273842ea6f8258233/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1", size = 34471544, upload-time = "2026-02-16T10:11:32.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/73/f237b2bc8c669212f842bcfd842b04fc8d936bfc9d471630569132dc920d/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500", size = 35949911, upload-time = "2026-02-16T10:11:39.813Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/86/b912195eee0903b5611bf596833def7d146ab2d301afeb4b722c57ffc966/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41", size = 44520337, upload-time = "2026-02-16T10:11:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c2/f2a717fb824f62d0be952ea724b4f6f9372a17eed6f704b5c9526f12f2f1/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07", size = 47548944, upload-time = "2026-02-16T10:11:56.607Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a7/90007d476b9f0dc308e3bc57b832d004f848fd6c0da601375d20d92d1519/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83", size = 48236269, upload-time = "2026-02-16T10:12:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3f/b16fab3e77709856eb6ac328ce35f57a6d4a18462c7ca5186ef31b45e0e0/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125", size = 50604794, upload-time = "2026-02-16T10:12:11.797Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a1/22df0620a9fac31d68397a75465c344e83c3dfe521f7612aea33e27ab6c0/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8", size = 27660642, upload-time = "2026-02-16T10:12:17.746Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]


### PR DESCRIPTION
This PR introduces documentation and snippets regarding the managements (and resolution) of conflicts in Bauplan. 

It revolves around 4 types of conflicts related to:
1. Concurrency
2. Naming
3. Schema
4. Corruption

Each type comes with one example composed of an explanatory README.md file and the code replicating the scenario. 