### PR TITLE
docs: add utilities scripts

### DIFF
--- a/examples/utils/01_find_transactional_branches/README.md
+++ b/examples/utils/01_find_transactional_branches/README.md
@@ -1,0 +1,30 @@
+# Find transactional branches
+
+Lists all transactional branches for a given Bauplan profile.
+
+Bauplan creates a transactional branch for every command that alters the state of the lake. These branches remain open if job execution fails, and should be either pruned or inspected for debugging.
+
+## Usage
+
+```sh
+uv run main.py [OPTIONS]
+```
+
+Run `uv run main.py --help` to see all available options.
+
+### Options
+
+| Option | Default | Description |
+|---|---|---|
+| `--profile` | `default` | Bauplan profile to use. |
+| `--verbose` | `False` | Print the full list of transactional branch names after the summary. |
+
+## Output
+
+Always prints the total count of transactional branches found and a breakdown by command, sorted from most to least frequent. With `--verbose`, also prints the full list of branch names.
+
+A transactional branch follows the naming pattern:
+
+```
+<user>.<branch>-bpln-tx-<command>-<timestamp>-<job_id>
+```

--- a/examples/utils/01_find_transactional_branches/main.py
+++ b/examples/utils/01_find_transactional_branches/main.py
@@ -1,0 +1,63 @@
+import bauplan
+
+import re
+import typer
+from typing import Annotated
+from collections import Counter
+
+
+def find_transactional_branches(
+    profile: Annotated[str, typer.Option(help="Bauplan profile to use")] = "default",
+    verbose: Annotated[
+        bool, typer.Option(help="Print all transactional branches")
+    ] = False,
+) -> None:
+    """
+    Retrieve transactional branches that can be pruned to clean up the lakehouse.
+
+    A transactional branch is created for any Bauplan command altering the state of the lake and remains open if job execution fails for some reason.
+
+    Given a transactional branch, its corresponding job should be in one of two states:
+        - 'failed': branch can be pruned or inspected for debugging
+        - 'running': branch cannot be pruned, job still in flight
+
+    Prints a breakdown of transactional branches by command, sorted from most to least frequent,
+    optionally followed by the full list of branch names.
+    """
+    client = bauplan.Client(profile=profile)
+
+    # Counter for commands
+    counter = Counter()
+
+    # Buffer to be used to print out branch names in verbose mode
+    buffer = []
+
+    # Transactional branches have a distinct pattern following <user>.<branch_name>-bpln-tx-<command>-<timestamp>-<job_id>
+    pattern_for_transactional = re.compile(
+        r"^(?P<user>[^.]+)\.(?P<branch>[^-]+)-bpln-tx-(?P<command>.+)-(?P<timestamp>\d{14})-(?P<job_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
+    )
+
+    # Pre-filter by branches whose name contain 'bpln-tx' which indicates transactional branches
+    for branch in client.get_branches(name="bpln-tx"):
+        # If branch matches pattern, then it's transactional.
+        match = pattern_for_transactional.fullmatch(branch.name)
+
+        if match is not None:
+            counter.update([match.groupdict().get("command")])
+            if verbose:
+                buffer.append(branch.name)
+
+    print(f"Found {counter.total()} transactional branches in profile '{profile}'.\n")
+
+    print("Command breakdown:")
+    for command, count in counter.most_common():
+        print(f"  {command:<30} {count}")
+
+    print()
+    if verbose:
+        for branch_name in buffer:
+            print(branch_name)
+
+
+if __name__ == "__main__":
+    typer.run(find_transactional_branches)

--- a/examples/utils/02_prune_transactional_branches/README.md
+++ b/examples/utils/02_prune_transactional_branches/README.md
@@ -1,0 +1,26 @@
+# Prune transactional branches
+
+Identifies dead transactional branches to clean up the lakehouse.
+
+Bauplan creates a transactional branch for every command that alters lake state. These branches remain open if job execution fails. This script finds branches whose corresponding job has failed in a user-provided time window, leaving branches with jobs still running untouched. If not in `dry-run` mode, these branches are pruned.
+
+## Usage
+
+```sh
+uv run main.py [OPTIONS]
+```
+
+Run `uv run main.py --help` to see all available options.
+
+### Options
+
+| Option | Default | Description |
+|---|---|---|
+| `--profile` | `default` | Bauplan profile to use. |
+| `--jobs-failed-after` | `None` | Only consider jobs that failed after this date (UTC). Leave empty to apply no lower bound. |
+| `--jobs-failed-before` | `None` | Only consider jobs that failed before this date (UTC). Leave empty to apply no upper bound. |
+| `--dry-run` / `--no-dry-run` | `True` | Print branches that would be pruned without deleting them. Pass `--no-dry-run` to actually delete. |
+
+## Output
+
+Prints the total count of dead transactional branches eligible for pruning and a breakdown by command type. In dry-run mode, also lists the branch names that would be deleted.

--- a/examples/utils/02_prune_transactional_branches/main.py
+++ b/examples/utils/02_prune_transactional_branches/main.py
@@ -1,0 +1,121 @@
+import bauplan
+from datetime import datetime, timezone
+from typing import Annotated
+from collections import Counter
+
+import re
+import typer
+
+
+def prune_branches(
+    profile: Annotated[str, typer.Option(help="Bauplan profile to use")] = "default",
+    jobs_failed_after: Annotated[
+        datetime | None,
+        typer.Option(
+            help="Only consider jobs that failed after this date (UTC). Leave empty to apply no lower bound"
+        ),
+    ] = None,
+    jobs_failed_before: Annotated[
+        datetime | None,
+        typer.Option(
+            help="Only consider jobs that failed before this date (UTC). Leave empty to apply no upper bound"
+        ),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option(help="Print branches that would be pruned without deleting them"),
+    ] = True,
+) -> None:
+    """
+    Prune dead transactional branches to clean up the lakehouse.
+
+    Bauplan creates a transactional branch for every command that alters lake state. These branches
+    remain open when job execution fails. This script identifies branches whose job has failed and
+    marks them for deletion, leaving branches with running jobs untouched.
+
+    An optional date range (--jobs-failed-after / --jobs-failed-before) narrows which failed jobs
+    are considered. Runs in dry-run mode by default; pass --no-dry-run to actually delete branches.
+    """
+    client = bauplan.Client(profile=profile)
+
+    # Enforce UTC timezone on date filters
+    if jobs_failed_after:
+        jobs_failed_after = jobs_failed_after.replace(tzinfo=timezone.utc)
+    if jobs_failed_before:
+        jobs_failed_before = jobs_failed_before.replace(tzinfo=timezone.utc)
+
+    if jobs_failed_after and jobs_failed_before:
+        if jobs_failed_before < jobs_failed_after:
+            raise ValueError("jobs_failed_before must be later than jobs_failed_after")
+
+    # Transactional branches have a distinct pattern following <user>.<branch_name>-bpln-tx-<command>-<timestamp>-<job_id>
+    pattern_for_transactional = re.compile(
+        r"^(?P<user>[^.]+)\.(?P<branch>[^-]+)-bpln-tx-(?P<command>.+)-(?P<timestamp>\d{14})-(?P<job_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
+    )
+
+    transactional_branches_data = []
+
+    # Transactional branches contain 'bpln-tx' in their name; pre-filter on that substring to 'push-down' filtering
+    for branch in client.get_branches(name="bpln-tx"):
+        match = pattern_for_transactional.fullmatch(branch.name)
+
+        if match is not None:
+            transactional_branches_data.append(
+                {
+                    **match.groupdict(),
+                    "name": branch.name,
+                }
+            )
+
+    # Retrieve IDs for all jobs which failed in a transactional branch and are within the required temporal window
+    failed_job_ids = [
+        failed_job.id
+        for failed_job in (
+            client.get_jobs(
+                all_users=True,
+                filter_by_ids=[
+                    datum.get("job_id") for datum in transactional_branches_data
+                ],
+                filter_by_statuses="fail",
+                filter_by_created_after=jobs_failed_after,
+                filter_by_created_before=jobs_failed_before,
+            )
+        )
+    ]
+
+    # Restrict to transactional branches that can actually be pruned (in window and whose job failed)
+    transactional_branches_to_prune = [
+        branch
+        for branch in transactional_branches_data
+        if branch.get("job_id") in failed_job_ids
+    ]
+
+    command_counter = Counter(
+        [branch.get("command") for branch in transactional_branches_to_prune]
+    )
+
+    print(
+        f"Found {len(transactional_branches_to_prune)} 'dead' transactional branches. These can be pruned.\n"
+    )
+    print("Breakdown by command:")
+    for k, v in command_counter.most_common():
+        print(f" {k:<20} {v}")
+
+    if dry_run:
+        print("\nDRY RUN ON. The job would have pruned the following branches:\n")
+
+    for branch in transactional_branches_to_prune:
+        branch_name = branch.get("name")
+        # In dry run, just print the branches that would have been pruned
+        if dry_run:
+            print(branch_name)
+        else:
+            try:
+                client.delete_branch(branch_name)
+                print(f"Delete branch {branch_name}")
+            except Exception as e:
+                print(f"Failed to delete branch {branch_name}. Error: {e}")
+
+
+if __name__ == "__main__":
+    typer.run(prune_branches)

--- a/examples/utils/README.md
+++ b/examples/utils/README.md
@@ -1,0 +1,24 @@
+# Bauplan utilities
+
+A (growing) collection of utilities to efficiently manage Bauplan.
+
+Each utility lives in its own directory with a `main.py` entry point and a `README.md` that explains its aim, the expected output, and why it matters.
+
+## Utilities
+
+| # | Directory | What it does |
+|---|---|---|
+| 01 | `00_find_transactional_branches` | List all transactional branches and how many each command left behind |
+| 02 | `01_prune_transactional_branches` | Identify and delete dead transactional branches left by failed jobs |
+
+## Running an example
+
+Every example uses `uv` for dependency management. From the example directory:
+
+```sh
+uv run main.py
+# or, to pick a non-default Bauplan profile:
+uv run main.py --profile <profile>
+```
+
+Run `uv run main.py --help` in any directory to see all available options.

--- a/examples/utils/pyproject.toml
+++ b/examples/utils/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "bauplan-utils"
+version = "0.1.0"
+description = "Utilities to manage Bauplan"
+readme = "README.md"
+requires-python = "==3.13.*"
+dependencies = [
+    "bauplan~=0.1.10",
+    "typer~=0.24.1",
+]

--- a/examples/utils/uv.lock
+++ b/examples/utils/uv.lock
@@ -1,0 +1,150 @@
+version = 1
+revision = 3
+requires-python = "==3.13.*"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "bauplan"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyarrow" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/b4/c30097c3838d3ebaa2efbfe0236061586429592158a0d230542467222a1f/bauplan-0.1.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4a9f64849227ca31f3a51e374303c73687ae9d5139764432f60e96c9296670bf", size = 16195221, upload-time = "2026-04-07T14:35:45.254Z" },
+    { url = "https://files.pythonhosted.org/packages/89/32/30ba3e92364ec1ed6ff9fddb0b30faa7eabea5344069d838acbfea707c39/bauplan-0.1.10-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:e46c3e702b8643eeb5b57c4540bdbd55a7fabf5ed86812a1909ec01c8f1e7f25", size = 16899059, upload-time = "2026-04-07T14:36:01.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/03/9fa03c21d081c18cdb2491b7422356c16eb9eccc01ce4ac50c57da44b4a0/bauplan-0.1.10-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:bc56325d7b6aeb149053c813cab74efb7a6da39330c56d0ee9f4688982785d21", size = 19166755, upload-time = "2026-04-07T14:35:52.198Z" },
+]
+
+[[package]]
+name = "bauplan-utils"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "bauplan" },
+    { name = "typer" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "bauplan", specifier = "~=0.1.10" },
+    { name = "typer", specifier = "~=0.24.1" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "23.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/10/2cbe4c6f0fb83d2de37249567373d64327a5e4d8db72f486db42875b08f6/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8", size = 34210066, upload-time = "2026-02-16T10:10:45.487Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/4f/679fa7e84dadbaca7a65f7cdba8d6c83febbd93ca12fa4adf40ba3b6362b/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f", size = 35825526, upload-time = "2026-02-16T10:10:52.266Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/63/d2747d930882c9d661e9398eefc54f15696547b8983aaaf11d4a2e8b5426/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677", size = 44473279, upload-time = "2026-02-16T10:11:01.557Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2", size = 47585798, upload-time = "2026-02-16T10:11:09.401Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/476943001c54ef078dbf9542280e22741219a184a0632862bca4feccd666/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37", size = 48179446, upload-time = "2026-02-16T10:11:17.781Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b6/5dd0c47b335fcd8edba9bfab78ad961bd0fd55ebe53468cc393f45e0be60/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2", size = 50623972, upload-time = "2026-02-16T10:11:26.185Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/09/a532297c9591a727d67760e2e756b83905dd89adb365a7f6e9c72578bcc1/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a", size = 27540749, upload-time = "2026-02-16T10:12:23.297Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8e/38749c4b1303e6ae76b3c80618f84861ae0c55dd3c2273842ea6f8258233/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1", size = 34471544, upload-time = "2026-02-16T10:11:32.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/73/f237b2bc8c669212f842bcfd842b04fc8d936bfc9d471630569132dc920d/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500", size = 35949911, upload-time = "2026-02-16T10:11:39.813Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/86/b912195eee0903b5611bf596833def7d146ab2d301afeb4b722c57ffc966/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41", size = 44520337, upload-time = "2026-02-16T10:11:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c2/f2a717fb824f62d0be952ea724b4f6f9372a17eed6f704b5c9526f12f2f1/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07", size = 47548944, upload-time = "2026-02-16T10:11:56.607Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a7/90007d476b9f0dc308e3bc57b832d004f848fd6c0da601375d20d92d1519/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83", size = 48236269, upload-time = "2026-02-16T10:12:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3f/b16fab3e77709856eb6ac328ce35f57a6d4a18462c7ca5186ef31b45e0e0/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125", size = 50604794, upload-time = "2026-02-16T10:12:11.797Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a1/22df0620a9fac31d68397a75465c344e83c3dfe521f7612aea33e27ab6c0/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8", size = 27660642, upload-time = "2026-02-16T10:12:17.746Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]


### PR DESCRIPTION
Add first two utilities to manage transactional branches. 

The first one, lets the user inspect and print the branches. This is mostly useful for e.g. agents, or to have a quick overview of how Bauplan operates. 

The second one, lets the user delete transactional branches in a definite time-window (e.g. before X, after Y, or between Y and X). A `dry-run` option allows the user to _not_ delete the branch: they are just printed.