### PR TITLE
docs: add -function postfix to fn links

### DIFF
--- a/docs/gen_sdk_reference.py
+++ b/docs/gen_sdk_reference.py
@@ -174,7 +174,7 @@ class TypeLinker:
                                 method_anchor = f'{anchor}-{cls_member.name.lower()}'
                                 self.register(f'{resolved.name}.{cls_member.name}', page, method_anchor)
                     case griffe.Kind.FUNCTION:
-                        anchor = f'{page}-{member.name.lower()}'
+                        anchor = function_slug(page, member.name)
                         self.register(resolved.name, page, anchor)
                     # MODULE case: handled by _walk_module_tree
 
@@ -451,7 +451,7 @@ def process_module(output_dir: Path, module: griffe.Module, linker: TypeLinker) 
                             process_class(f, toc, member, linker, page_slug=name)
                     case griffe.Kind.FUNCTION:
                         with wrap(f, 'PyModuleMember', member.name):
-                            process_function(f, toc, 2, member, linker, slug=f'{name}-{member.name.lower()}')
+                            process_function(f, toc, 2, member, linker, slug=function_slug(name, member.name))
                     case griffe.Kind.MODULE:
                         pass  # handled by _walk_module_tree
                     case _:
@@ -803,6 +803,10 @@ def wrap(output: TextIO, component_name: str, comment: str | None = None) -> Ite
 
 def jsx_comment(text: str) -> str:
     return '{/* ' + html.escape(text) + ' */}'
+
+
+def function_slug(page_slug: str, function_name: str) -> str:
+    return f'{page_slug}-{function_name.lower()}-function'
 
 
 def path_slug(obj: griffe.Object) -> str:

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -108,7 +108,7 @@ machines.
 ## I already have a lot of Spark code, can I run it with Bauplan?
 
 Yes, Bauplan supports **PySpark** functions - see our
-[docs](/reference/bauplan#bauplan-pyspark) for details - so you can
+[docs](/reference/bauplan#bauplan-pyspark-function) for details - so you can
 copy and paste your PySpark code and run it on Bauplan. However, for now
 we run your PySpark code on a **single-node architecture** rather than a
 distributed cluster, so you should ensure your jobs are not too large.


### PR DESCRIPTION
### Add -function postfix to function entries in SDK reference
Functions and classes in the SDK reference currently share the same link-generated format, making them both have the same link for stuff like `class Model` and `def model()`. This PR appends a -function postfix to function entries so these can be clearly differentiated.

This was brought up today by @giacomopiccinini.