### PR TITLE
build: restrict windows arm64 wheel matrix to python 3.12+

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,23 +29,30 @@ jobs:
       run:
         shell: bash
     strategy:
+      fail-fast: false
       matrix:
         include:
           - runner: blacksmith-16vcpu-ubuntu-2404
             os: linux
             arch: amd64
+            pythons: "python3.10 python3.11 python3.12 python3.13 python3.14"
           - runner: blacksmith-16vcpu-ubuntu-2404-arm
             os: linux
             arch: arm64
+            pythons: "python3.10 python3.11 python3.12 python3.13 python3.14"
           - runner: macos-latest
             os: macos
             arch: arm64
+            pythons: "python3.10 python3.11 python3.12 python3.13 python3.14"
           - runner: windows-latest
             os: windows
             arch: amd64
+            pythons: "python3.10 python3.11 python3.12 python3.13 python3.14"
           - runner: windows-11-arm
             os: windows
             arch: arm64
+            # python-build-standalone only publishes Windows ARM64 builds from 3.12 onwards.
+            pythons: "python3.12 python3.13 python3.14"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -66,7 +73,9 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('Cargo.lock') }}
 
       - name: Install Python versions
-        run: uv python install 3.10 3.11 3.12 3.13 3.14
+        env:
+          PYTHONS: ${{ matrix.pythons }}
+        run: uv python install $PYTHONS
 
       - name: Build CLI binary
         env:
@@ -81,7 +90,7 @@ jobs:
         with:
           args: >-
             --release --out dist
-            -i python3.10 python3.11 python3.12 python3.13 python3.14
+            -i ${{ matrix.pythons }}
           docker-options: -v ~/.cargo:/root/.cargo
           before-script-linux: |
             ARCH=$(uname -m | sed 's/aarch64/aarch_64/')


### PR DESCRIPTION
Release on `windows-11-arm` failed because `python-build-standalone` does not publish `Python 3.10` and `3.11` for `Windows ARM64`, so maturin fell back to bundled sysconfig and could not link.
Also adds `fail-fast: false` so a single runner failure stops cancelling the other four mid-run; `needs: build` on the publish job still gates the actual release on all-green.

Failed build:
- https://github.com/BauplanLabs/bauplan/actions/runs/24659675343/job/72102141414

```
📦 Including license file `LICENSE-APACHE`
📦 Including license file `LICENSE-MIT`
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings
⚠️  Warning: Failed to determine python platform
⚠️  Warning: Failed to determine python platform
💥 maturin failed
  Caused by: Interpreters ["CPython 3.10", "CPython 3.11"] were found in maturin's bundled sysconfig, but compiling for Windows without an interpreter requires PyO3's `generate-import-lib` feature
Error: The process 'C:\a\_temp\d5d658cd-1f95-4f1d-83cd-ec4503dd7147\maturin.exe' failed with exit code 1
    at ExecState._setResult (file:///C:/a/_actions/PyO3/maturin-action/04ac600d27cdf7a9a280dadf7147097c42b757ad/dist/index.js:44149:25)
    at ExecState.CheckComplete (file:///C:/a/_actions/PyO3/maturin-action/04ac600d27cdf7a9a280dadf7147097c42b757ad/dist/index.js:44132:18)
    at ChildProcess.<anonymous> (file:///C:/a/_actions/PyO3/maturin-action/04ac600d27cdf7a9a280dadf7147097c42b757ad/dist/index.js:44028:27)
    at ChildProcess.emit (node:events:508:28)
    at maybeClose (node:internal/child_process:1100:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5)
Error: The process 'C:\a\_temp\d5d658cd-1f95-4f1d-83cd-ec4503dd7147\maturin.exe' failed with exit code 1
```