### PR TITLE
fix: percent-encode URL path segments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,7 @@ dependencies = [
  "nondestructive",
  "opentelemetry",
  "parquet",
+ "percent-encoding",
  "polyglot-sql",
  "predicates",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ polyglot-sql = "0.1"
 prost = "0.14"
 prost-types = "0.14"
 parquet = { version = "57", optional = true }
+percent-encoding = "2"
 pyo3 = { version = "0.28", optional = true, features = ["experimental-inspect", "multiple-pymethods"] }
 pyo3-arrow = { version = "0.16", optional = true }
 pyo3-log = { version = "0.13", optional = true }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,8 +1,10 @@
 // ApiError is just over the threshold.
 #![allow(clippy::result_large_err)]
 
+use std::borrow::Cow;
 use std::io::Read;
 
+use percent_encoding::{AsciiSet, CONTROLS, PercentEncode, utf8_percent_encode};
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
@@ -22,6 +24,32 @@ pub(crate) mod testutil;
 
 pub use error::*;
 pub use paginate::*;
+
+/// A percent-encoded URL path for an API request.
+#[derive(Debug)]
+pub struct PathArgs(Cow<'static, str>);
+
+fn encode_segment(s: &str) -> PercentEncode<'_> {
+    // WHATWG path percent-encode set (https://url.spec.whatwg.org/#path-percent-encode-set)
+    // extended with `/` and `%` to treat the input as a single segment.
+    const SEGMENT: &AsciiSet = &CONTROLS
+        .add(b' ').add(b'"').add(b'<').add(b'>').add(b'`')
+        .add(b'#').add(b'?').add(b'{').add(b'}')
+        .add(b'/').add(b'%');
+    utf8_percent_encode(s, SEGMENT)
+}
+
+macro_rules! urlformat {
+    ($fmt:literal) => {
+        $crate::api::PathArgs(::std::borrow::Cow::Borrowed($fmt))
+    };
+    ($fmt:literal, $($arg:expr),+ $(,)?) => {
+        $crate::api::PathArgs(::std::borrow::Cow::Owned(format!(
+            $fmt, $($crate::api::encode_segment($arg)),+
+        )))
+    };
+}
+pub(crate) use urlformat;
 
 #[derive(Debug, Deserialize)]
 struct RawMetadata {
@@ -47,8 +75,8 @@ pub trait ApiRequest: Sized {
     /// The corresponding response type.
     type Response: ApiResponse;
 
-    /// The path that the request should take.
-    fn path(&self) -> String;
+    /// The path that the request should take. Construct with [`urlformat!`].
+    fn path(&self) -> PathArgs;
 
     /// The method to use.
     fn method(&self) -> http::Method {
@@ -69,10 +97,11 @@ pub trait ApiRequest: Sized {
     /// to your favorite HTTP client.
     fn into_request(self, profile: &Profile) -> Result<http::Request<String>, http::Error> {
         let method = self.method();
-        let mut path = self.path();
+        let path = self.path().0;
         let mut parts = profile.api_endpoint.clone().into_parts();
 
-        if let Some(qs) = self.query() {
+        let path = if let Some(qs) = self.query() {
+            let mut path = path.into_owned();
             path.push('?');
 
             // SAFETY: query strings should only be valid UTF-8.
@@ -80,7 +109,11 @@ pub trait ApiRequest: Sized {
                 serde_qs::to_writer(&qs, &mut path.as_mut_vec())
                     .expect("query string serialization should be infallible");
             }
-        }
+
+            Cow::Owned(path)
+        } else {
+            path
+        };
 
         parts.path_and_query = Some(path.parse()?);
 
@@ -181,5 +214,38 @@ impl ApiResponse for CatalogRef {
             }
             RawApiResponse::Error { error } => Err(ApiError::from_raw(parts.status, error)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    #[test]
+    fn urlformat_static_is_borrowed() {
+        let p = urlformat!("/catalog/v0/branches").0;
+        assert!(matches!(p, Cow::Borrowed("/catalog/v0/branches")));
+    }
+
+    #[test]
+    fn urlformat_parameterized_is_owned_and_encoded() {
+        let p = urlformat!("/catalog/v0/branches/{}", "feature/foo").0;
+        assert!(matches!(p, Cow::Owned(s) if s == "/catalog/v0/branches/feature%2Ffoo"));
+    }
+
+    #[test]
+    fn urlformat_encodes_expected_chars() {
+        assert_eq!(urlformat!("/{}", "main").0, "/main");
+        assert_eq!(urlformat!("/{}", "main@abc123").0, "/main@abc123");
+        assert_eq!(urlformat!("/{}", "a b").0, "/a%20b");
+        assert_eq!(urlformat!("/{}", "100%").0, "/100%25");
+        assert_eq!(urlformat!("/{}", "café").0, "/caf%C3%A9");
+        // Iceberg multi-level namespace separator (U+001F) must encode to %1F.
+        assert_eq!(urlformat!("/{}", "a\u{1f}b").0, "/a%1Fb");
+        // Multi-arg: each segment is encoded independently.
+        assert_eq!(
+            urlformat!("/refs/{}/namespaces/{}", "feature/foo", "a b").0,
+            "/refs/feature%2Ffoo/namespaces/a%20b",
+        );
     }
 }

--- a/src/api/branch.rs
+++ b/src/api/branch.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     CatalogRef, PaginatedResponse,
-    api::{ApiRequest, DataResponse},
+    api::{ApiRequest, DataResponse, PathArgs, urlformat},
 };
 
 /// A branch in the catalog.
@@ -32,8 +32,8 @@ pub struct GetBranch<'a> {
 impl ApiRequest for GetBranch<'_> {
     type Response = Branch;
 
-    fn path(&self) -> String {
-        format!("/catalog/v0/branches/{}", self.name)
+    fn path(&self) -> PathArgs {
+        urlformat!("/catalog/v0/branches/{}", self.name)
     }
 }
 
@@ -58,8 +58,8 @@ struct GetBranchesQuery<'a> {
 impl ApiRequest for GetBranches<'_> {
     type Response = PaginatedResponse<Branch>;
 
-    fn path(&self) -> String {
-        "/catalog/v0/branches".to_string()
+    fn path(&self) -> PathArgs {
+        urlformat!("/catalog/v0/branches")
     }
 
     fn query(&self) -> Option<impl Serialize> {
@@ -93,8 +93,8 @@ impl ApiRequest for CreateBranch<'_> {
         http::Method::POST
     }
 
-    fn path(&self) -> String {
-        "/catalog/v0/branches".to_string()
+    fn path(&self) -> PathArgs {
+        urlformat!("/catalog/v0/branches")
     }
 
     fn body(&self) -> Option<impl Serialize> {
@@ -119,8 +119,8 @@ impl ApiRequest for DeleteBranch<'_> {
         http::Method::DELETE
     }
 
-    fn path(&self) -> String {
-        format!("/catalog/v0/branches/{}", self.name)
+    fn path(&self) -> PathArgs {
+        urlformat!("/catalog/v0/branches/{}", self.name)
     }
 }
 
@@ -146,8 +146,8 @@ impl ApiRequest for RenameBranch<'_> {
         http::Method::PATCH
     }
 
-    fn path(&self) -> String {
-        format!("/catalog/v0/branches/{}", self.name)
+    fn path(&self) -> PathArgs {
+        urlformat!("/catalog/v0/branches/{}", self.name)
     }
 
     fn body(&self) -> Option<impl Serialize> {
@@ -193,10 +193,11 @@ impl ApiRequest for MergeBranch<'_> {
         http::Method::POST
     }
 
-    fn path(&self) -> String {
-        format!(
+    fn path(&self) -> PathArgs {
+        urlformat!(
             "/catalog/v0/refs/{}/merge/{}",
-            self.source_ref, self.into_branch
+            self.source_ref,
+            self.into_branch,
         )
     }
 

--- a/src/api/commit.rs
+++ b/src/api/commit.rs
@@ -5,7 +5,11 @@ use std::collections::BTreeMap;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::{CatalogRef, PaginatedResponse, api::ApiRequest, branch::Branch};
+use crate::{
+    CatalogRef, PaginatedResponse,
+    api::{ApiRequest, PathArgs, urlformat},
+    branch::Branch,
+};
 
 /// An actor (author or committer) in a commit.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -216,8 +220,8 @@ struct GetCommitsQuery<'a> {
 impl ApiRequest for GetCommits<'_> {
     type Response = PaginatedResponse<Commit>;
 
-    fn path(&self) -> String {
-        format!("/catalog/v0/refs/{}/commits", self.at_ref)
+    fn path(&self) -> PathArgs {
+        urlformat!("/catalog/v0/refs/{}/commits", self.at_ref)
     }
 
     fn query(&self) -> Option<impl Serialize> {

--- a/src/api/iceberg.rs
+++ b/src/api/iceberg.rs
@@ -6,7 +6,10 @@
 
 use iceberg_catalog_rest::{LoadTableResult as IcebergTable, RegisterTableRequest};
 
-use crate::{ApiRequest, ApiResponse};
+use crate::{
+    ApiRequest, ApiResponse,
+    api::{PathArgs, urlformat},
+};
 
 /// Register a table in a namespace on a branch, using an existing metadata
 /// file.
@@ -31,10 +34,11 @@ impl ApiRequest for RegisterTable<'_> {
         http::Method::POST
     }
 
-    fn path(&self) -> String {
-        format!(
+    fn path(&self) -> PathArgs {
+        urlformat!(
             "/iceberg/v1/{}/namespaces/{}/register",
-            self.branch, self.namespace,
+            self.branch,
+            self.namespace,
         )
     }
 

--- a/src/api/namespace.rs
+++ b/src/api/namespace.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     CatalogRef, PaginatedResponse,
-    api::{ApiRequest, DataResponse, commit::CommitOptions},
+    api::{ApiRequest, DataResponse, PathArgs, commit::CommitOptions, urlformat},
 };
 
 /// A container for organizing tables.
@@ -41,8 +41,12 @@ pub struct GetNamespace<'a> {
 impl ApiRequest for GetNamespace<'_> {
     type Response = Namespace;
 
-    fn path(&self) -> String {
-        format!("/catalog/v0/refs/{}/namespaces/{}", self.at_ref, self.name)
+    fn path(&self) -> PathArgs {
+        urlformat!(
+            "/catalog/v0/refs/{}/namespaces/{}",
+            self.at_ref,
+            self.name,
+        )
     }
 }
 
@@ -65,8 +69,8 @@ struct GetNamespacesQuery<'a> {
 impl ApiRequest for GetNamespaces<'_> {
     type Response = PaginatedResponse<Namespace>;
 
-    fn path(&self) -> String {
-        format!("/catalog/v0/refs/{}/namespaces", self.at_ref)
+    fn path(&self) -> PathArgs {
+        urlformat!("/catalog/v0/refs/{}/namespaces", self.at_ref)
     }
 
     fn query(&self) -> Option<impl Serialize> {
@@ -103,8 +107,8 @@ impl ApiRequest for CreateNamespace<'_> {
         http::Method::POST
     }
 
-    fn path(&self) -> String {
-        format!("/catalog/v0/branches/{}/namespaces", self.branch)
+    fn path(&self) -> PathArgs {
+        urlformat!("/catalog/v0/branches/{}/namespaces", self.branch)
     }
 
     fn body(&self) -> Option<impl Serialize> {
@@ -141,10 +145,11 @@ impl ApiRequest for DeleteNamespace<'_> {
         http::Method::DELETE
     }
 
-    fn path(&self) -> String {
-        format!(
+    fn path(&self) -> PathArgs {
+        urlformat!(
             "/catalog/v0/branches/{}/namespaces/{}",
-            self.branch, self.name
+            self.branch,
+            self.name,
         )
     }
 

--- a/src/api/paginate.rs
+++ b/src/api/paginate.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::ApiRequest;
 
-use super::{ApiError, ApiResponse, RawApiResponse};
+use super::{ApiError, ApiResponse, PathArgs, RawApiResponse};
 
 /// A request with a pagination token and limit attached.
 pub struct PaginatedRequest<'a, T> {
@@ -40,7 +40,7 @@ where
 impl<T: ApiRequest> ApiRequest for PaginatedRequest<'_, T> {
     type Response = T::Response;
 
-    fn path(&self) -> String {
+    fn path(&self) -> PathArgs {
         self.base.path()
     }
 

--- a/src/api/table.rs
+++ b/src/api/table.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 
 use crate::{
     CatalogRef, PaginatedResponse,
-    api::{ApiRequest, DataResponse, commit::CommitOptions},
+    api::{ApiRequest, DataResponse, PathArgs, commit::CommitOptions, urlformat},
 };
 
 /// A field in a table schema.
@@ -197,8 +197,12 @@ struct GetTableQuery<'a> {
 impl ApiRequest for GetTable<'_> {
     type Response = Table;
 
-    fn path(&self) -> String {
-        format!("/catalog/v0/refs/{}/tables/{}", self.at_ref, self.name)
+    fn path(&self) -> PathArgs {
+        urlformat!(
+            "/catalog/v0/refs/{}/tables/{}",
+            self.at_ref,
+            self.name,
+        )
     }
 
     fn query(&self) -> Option<impl Serialize> {
@@ -234,8 +238,8 @@ struct GetTablesQuery<'a> {
 impl ApiRequest for GetTables<'_> {
     type Response = PaginatedResponse<Table>;
 
-    fn path(&self) -> String {
-        format!("/catalog/v0/refs/{}/tables", self.at_ref)
+    fn path(&self) -> PathArgs {
+        urlformat!("/catalog/v0/refs/{}/tables", self.at_ref)
     }
 
     fn query(&self) -> Option<impl Serialize> {
@@ -283,9 +287,12 @@ impl ApiRequest for DeleteTable<'_> {
         http::Method::DELETE
     }
 
-    fn path(&self) -> String {
-        let DeleteTable { branch, name, .. } = self;
-        format!("/catalog/v0/branches/{branch}/tables/{name}")
+    fn path(&self) -> PathArgs {
+        urlformat!(
+            "/catalog/v0/branches/{}/tables/{}",
+            self.branch,
+            self.name,
+        )
     }
 
     fn query(&self) -> Option<impl Serialize> {
@@ -339,15 +346,13 @@ impl ApiRequest for RevertTable<'_> {
         http::Method::POST
     }
 
-    fn path(&self) -> String {
-        let Self {
-            name,
-            source_ref,
-            into_branch,
-            ..
-        } = self;
-
-        format!("/catalog/v0/refs/{source_ref}/tables/{name}/revert/{into_branch}")
+    fn path(&self) -> PathArgs {
+        urlformat!(
+            "/catalog/v0/refs/{}/tables/{}/revert/{}",
+            self.source_ref,
+            self.name,
+            self.into_branch,
+        )
     }
 
     fn body(&self) -> Option<impl Serialize> {

--- a/src/api/tag.rs
+++ b/src/api/tag.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     PaginatedResponse,
-    api::{ApiRequest, DataResponse},
+    api::{ApiRequest, DataResponse, PathArgs, urlformat},
 };
 
 /// A tag in the catalog.
@@ -28,8 +28,8 @@ pub struct GetTag<'a> {
 impl ApiRequest for GetTag<'_> {
     type Response = Tag;
 
-    fn path(&self) -> String {
-        format!("/catalog/v0/tags/{}", self.name)
+    fn path(&self) -> PathArgs {
+        urlformat!("/catalog/v0/tags/{}", self.name)
     }
 }
 
@@ -49,8 +49,8 @@ struct GetTagsQuery<'a> {
 impl ApiRequest for GetTags<'_> {
     type Response = PaginatedResponse<Tag>;
 
-    fn path(&self) -> String {
-        "/catalog/v0/tags".to_string()
+    fn path(&self) -> PathArgs {
+        urlformat!("/catalog/v0/tags")
     }
 
     fn query(&self) -> Option<impl Serialize> {
@@ -83,8 +83,8 @@ impl ApiRequest for CreateTag<'_> {
         http::Method::POST
     }
 
-    fn path(&self) -> String {
-        "/catalog/v0/tags".to_string()
+    fn path(&self) -> PathArgs {
+        urlformat!("/catalog/v0/tags")
     }
 
     fn body(&self) -> Option<impl Serialize> {
@@ -109,8 +109,8 @@ impl ApiRequest for DeleteTag<'_> {
         http::Method::DELETE
     }
 
-    fn path(&self) -> String {
-        format!("/catalog/v0/tags/{}", self.name)
+    fn path(&self) -> PathArgs {
+        urlformat!("/catalog/v0/tags/{}", self.name)
     }
 }
 
@@ -136,8 +136,8 @@ impl ApiRequest for RenameTag<'_> {
         http::Method::PATCH
     }
 
-    fn path(&self) -> String {
-        format!("/catalog/v0/tags/{}", self.name)
+    fn path(&self) -> PathArgs {
+        urlformat!("/catalog/v0/tags/{}", self.name)
     }
 
     fn body(&self) -> Option<impl Serialize> {


### PR DESCRIPTION
User-provided identifiers (branches, tags, namespaces, tables, refs) were interpolated raw into request paths, breaking values that contain reserved characters such as `/`.
Each path segment is now encoded per RFC 3986, leaving final validation of the decoded value to the server.