### PR TITLE
fix: update teardown behavior for p2p connections

### DIFF
--- a/bauplan-longbow/src/client.rs
+++ b/bauplan-longbow/src/client.rs
@@ -155,11 +155,7 @@ pub async fn fetch_query_results(
                         return Ok(Some((batch, state)));
                     }
                 }
-                None => {
-                    // The conn.close() in Drop sends the close frame.
-                    // Endpoint cleanup happens asynchronously.
-                    return Ok(None);
-                }
+                None => return Ok(None),
             }
         }
     }));

--- a/bauplan-longbow/src/server.rs
+++ b/bauplan-longbow/src/server.rs
@@ -125,11 +125,7 @@ impl ArrowIPCServer {
 
         // Signal that no more data will be sent.
         let _ = self.send.finish();
-
-        // Wait briefly for the FIN to be acknowledged, but don't block
-        // indefinitely — QUIC's reliability layer ensures delivery.
-        let _ =
-            tokio::time::timeout(std::time::Duration::from_millis(500), self.send.stopped()).await;
+        self.send.stopped().await.map_err(|_| Error::StreamClosed)?;
 
         self.endpoint.close().await;
         Ok(())

--- a/src/python/query.rs
+++ b/src/python/query.rs
@@ -121,9 +121,13 @@ impl Client {
             let addr = bauplan_longbow::iroh::EndpointAddr::new(public_key);
             let addr = preset.add_relay_urls(addr);
 
-            let (schema, stream) = bauplan_longbow::fetch_query_results(preset, addr)
-                .await
-                .map_err(query_err)?;
+            let (schema, stream) = tokio::time::timeout(timeout, async {
+                bauplan_longbow::fetch_query_results(preset, addr)
+                    .await
+                    .map_err(query_err)
+            })
+            .await
+            .map_err(|_| query_err("timed out fetching query results"))??;
 
             let schema: Schema = schema.as_ref().clone();
             return Ok((schema, Either::Left(stream.map_err(query_err))));


### PR DESCRIPTION
#197 introduced p2p connections for fetching query results, but I accidentally pushed the wrong revision and it had some experimental code that I wasn't really happy with.