### PR TITLE
build: don't tag bauplan-longbow releases

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,13 @@
 [workspace]
 git_only = true
 publish = false
+git_tag_name = "v{{ version }}"
+git_release_name = "v{{ version }}"
+
+[[package]]
+name = "bauplan-longbow"
+release = false
+changelog_update = false
 
 [changelog]
 trim = true


### PR DESCRIPTION
Since we merged `bauplan-longbow` and made the repo a workspace, release-plz started tagging both packages and trying to create releases for longbow. We want to keep the existing tagging scheme; the packages are versioned together anyway.