### PR TITLE
build: fix `release-plz pr`

### DIFF
--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -2,8 +2,7 @@ name: Release-plz
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
 
 permissions: {}
 
@@ -48,7 +47,6 @@ jobs:
     uses: ./.github/workflows/publish.yaml
     with:
       tag: ${{ needs.release-plz-release.outputs.tag }}
-
 
   # Deploy docs for the new version.
   docs:

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ node = "lts"
 "npm:mdx2vast" = "0.3.1"
 pinact = "3.9.0"
 protoc = "31"
-rust = { version = "1.92.0", profile = "default" }
+rust = { version = "1.95.0", profile = "default" }
 uv = "0.10"
 vale = "3.14.1"
 zizmor = "1.23.1"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,14 @@
 [workspace]
 git_only = true
 publish = false
+
+[[package]]
+name = "bauplan"
+release = true
+changelog_update = true
+changelog_path = "./CHANGELOG.md"
+git_tag_enable = true
+git_release_enable = true
 git_tag_name = "v{{ version }}"
 git_release_name = "v{{ version }}"
 
@@ -8,6 +16,14 @@ git_release_name = "v{{ version }}"
 name = "bauplan-longbow"
 release = false
 changelog_update = false
+git_tag_enable = false
+git_release_enable = false
+# This seems to be the only way to get `release-plz release-pr` to ignore
+# bauplan-longbow (it should be ignored because of release = false).
+# This works because it thinks it's the initial release of bauplan-longbow each
+# time.
+# https://github.com/release-plz/release-plz/issues/2595
+git_tag_name = "_nonexistent"
 
 [changelog]
 trim = true


### PR DESCRIPTION
It's choking on bauplan-longbow (and failing to determine the version) because, near as I can tell, there's a bug where `release = false` is only respected *after* determining the version. There's no version to determine for longbow because it's tied to the workspace version.

Setting a nonexistent tag works because it sees that the tag doesn't exist and assumes it's a brand new library; then it sees `publish = false` and skips the package altogether.

I couldn't find a better way to do this. I also updated the changelog configuration to match the docs:

https://release-plz.dev/docs/extra/single-changelog