### PR TITLE
build: tweak release-plz PR name

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -11,6 +11,7 @@ git_tag_enable = true
 git_release_enable = true
 git_tag_name = "v{{ version }}"
 git_release_name = "v{{ version }}"
+pr_name = "chore: release v{{version}}"
 
 [[package]]
 name = "bauplan-longbow"


### PR DESCRIPTION
This is related to the addition of the bauplan-longbow package. See #218. The current naming would fail gitlint.