### PR TITLE
fix: statically link the msvc crt in windows binaries

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+# Statically link the MSVC runtime (VCRUNTIME140, MSVCP140, ...) into
+# Windows binaries and cdylibs so the wheel and the standalone .exe
+# work on machines without the Visual C++ Redistributable installed.
+[target.'cfg(all(windows, target_env = "msvc"))']
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
The pysdk already worked on vanilla Windows because python-build-standalone ships `VCRUNTIME140.dll` next to `python.exe`, letting the `.pyd` inherit it at load time.
The standalone `bauplan.exe` had no such host and failed without the `VC++ Redistributable` installed; linking the `MSVC CRT` statically makes the `.exe` self-contained on all native Windows targets.