### PR TITLE
docs: change the order of generation cmds

### DIFF
--- a/docs/Justfile
+++ b/docs/Justfile
@@ -4,9 +4,9 @@ install:
 generate:
     uv sync --reinstall-package bauplan
     uv run gen_sdk_reference.py
+    cargo run --quiet --manifest-path ../Cargo.toml --bin gen-cli-docs > pages/reference/cli.mdx
     bun run generate-llm-docs
     bun run generate-llms-txt
-    cargo run --quiet --manifest-path ../Cargo.toml --bin gen-cli-docs > pages/reference/cli.mdx
 
 build out_dir="./build": install generate
     bun run docusaurus build --out-dir "{{ out_dir }}"

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,8 +1,9 @@
 {
   "scripts": {
+    "generate-cli-docs": "cargo run --quiet --manifest-path ../Cargo.toml --bin gen-cli-docs > pages/reference/cli.mdx",
     "generate-llm-docs": "node scripts/generate-llm-docs.js",
     "generate-llms-txt": "node scripts/generate-llms-txt.js",
-    "prebuild": "npm run generate-llm-docs && npm run generate-llms-txt",
+    "prebuild": "npm run generate-cli-docs && npm run generate-llm-docs && npm run generate-llms-txt",
     "build": "docusaurus build",
     "start": "docusaurus start",
     "serve": "docusaurus serve",


### PR DESCRIPTION
The order of operations in the generation script was wrong, and cli.mdx didn't exist at the time of running the `generate-llm-docs` command, therefore cli.md page was missing. Fixing it with this PR.