### PR TITLE
Fix endpoint for oauth

### DIFF
--- a/docs/pages/integrations/data-int-and-etl/estuary.mdx
+++ b/docs/pages/integrations/data-int-and-etl/estuary.mdx
@@ -256,7 +256,7 @@ In Estuary, create a new **Apache Iceberg** materialization and configure it as 
 | **Namespace** | Your target namespace in Bauplan |
 | **Base Location** | `s3://<your-bauplan-bucket>/iceberg` |
 | **Catalog Authentication** | OAuth 2.0 Client Credentials |
-| **OAuth 2.0 Server URI** | `api/v1/oauth/tokens` |
+| **OAuth 2.0 Server URI** | `v1/oauth/tokens` |
 | **Catalog Credential** | `<client_id>:<client_secret>` (from Step 1) |
 | **Scope** | *(leave empty)* |
 


### PR DESCRIPTION
The old endpoint (`api/v1/oauth/tokens`) only worked if the ingestion branch was main. When another branch was specified, it failed to work. This one has now been tested to work correctly. 