### PR TITLE
docs: add comments on case sensitivity

### DIFF
--- a/python/bauplan/__init__.pyi
+++ b/python/bauplan/__init__.pyi
@@ -1508,7 +1508,7 @@ class Client:
         ```
 
         Parameters:
-            query: The Bauplan query to execute.
+            query: The Bauplan query to execute. Column and table names are case-sensitive.
             ref: The ref, branch name or tag name to query from.
             max_rows: The maximum number of rows to return; default: `None` (no limit).
             cache: Whether to enable or disable caching for the query.
@@ -1550,7 +1550,7 @@ class Client:
 
         Parameters:
             path: The name or path of the file csv to write the results to.
-            query: The Bauplan query to execute.
+            query: The Bauplan query to execute. Column and table names are case-sensitive.
             ref: The ref, branch name or tag name to query from.
             max_rows: The maximum number of rows to return; default: `None` (no limit).
             cache: Whether to enable or disable caching for the query.
@@ -1592,7 +1592,7 @@ class Client:
         ```
 
         Parameters:
-            query: The Bauplan query to execute.
+            query: The Bauplan query to execute. Column and table names are case-sensitive.
             ref: The ref, branch name or tag name to query from.
             max_rows: The maximum number of rows to return; default: `None` (no limit).
             cache: Whether to enable or disable caching for the query.
@@ -1636,7 +1636,7 @@ class Client:
 
         Parameters:
             path: The name or path of the file json to write the results to.
-            query: The Bauplan query to execute.
+            query: The Bauplan query to execute. Column and table names are case-sensitive.
             file_format: The format to write the results in; default: `json`. Allowed values are 'json' and 'jsonl'.
             ref: The ref, branch name or tag name to query from.
             max_rows: The maximum number of rows to return; default: `None` (no limit).
@@ -1678,7 +1678,7 @@ class Client:
 
         Parameters:
             path: The name or path of the file parquet to write the results to.
-            query: The Bauplan query to execute.
+            query: The Bauplan query to execute. Column and table names are case-sensitive.
             ref: The ref, branch name or tag name to query from.
             max_rows: The maximum number of rows to return; default: `None` (no limit).
             cache: Whether to enable or disable caching for the query.

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -41,7 +41,7 @@ use tabwriter::TabWriter;
   bauplan query --no-trunc \"SELECT * FROM wide_table\"
 "))]
 pub(crate) struct QueryArgs {
-    /// Sql
+    /// SQL query. Column and table names are case-sensitive
     pub sql: Option<String>,
     /// Ref or branch name to run query against [default: active branch]
     #[arg(short, long)]


### PR DESCRIPTION
Specify in CLI and SDK that queries are fully case sensitive. 