### PR TITLE
feat: Type Contracts

### DIFF
--- a/python/bauplan/__init__.py
+++ b/python/bauplan/__init__.py
@@ -1,4 +1,7 @@
-from bauplan._internal import __version__
+from bauplan._internal import (
+    __version__,
+    __bpln_feature_typecontracts__,
+)
 
 # Re-export everything from the extension module.
 from bauplan._internal import (
@@ -56,3 +59,14 @@ __all__ = [
     "resources",
     "synthetic_model",
 ]
+
+if __bpln_feature_typecontracts__:
+    from bauplan._contracts import Artifact, Catalog, ModelTask
+
+    __all__.extend(
+        [
+            "Artifact",
+            "Catalog",
+            "ModelTask",
+        ]
+    )

--- a/python/bauplan/_contracts.py
+++ b/python/bauplan/_contracts.py
@@ -1,0 +1,167 @@
+"""
+Module containing support classes for type contracts.
+
+This includes a "registry" metaclass, `RegistryMeta`, that enables type-based syntax and
+value-based syntax for a registry. For example, the Artifact registry supports type-based syntax
+such as `Artifact[<schema_type>]` to represent the schema of a table that has been materialized in
+the artifact store. In contrast, Parameter registry supports value-based syntax such as
+`Parameter.param_name` to represent the value of the bauplan project parameter "param_name".
+"""
+
+from __future__ import annotations
+
+import sys
+import functools
+import pyarrow
+from typing import Any, Callable, Optional, TypeVar, Generic
+
+if sys.version_info >= (3, 11):
+    from typing import LiteralString
+else:
+    from typing_extensions import LiteralString
+
+from bauplan._internal import __bpln_feature_typecontracts__
+
+
+if __bpln_feature_typecontracts__:
+    # Experimental: "registry" structures for Generic types
+
+    EntryNameType = TypeVar(name="EntryNameType", bound=LiteralString)
+
+    class GenericTypeEntry(Generic[EntryNameType]):
+        """
+        A base generic type for entries in a Type Registry. This supports syntax like
+        `Registry["entry_name"]` to specify that an object"s type corresponds to the entry,
+        "entry_name", in the registry "Registry".
+        """
+
+        ...
+
+    class SchemaEntry(GenericTypeEntry[EntryNameType]):
+        """A type for schemas stored in a Type Registry."""
+
+        ...
+
+    class TypeRegistryMeta(type):
+        """
+        A metaclass for a registry to support subscript syntax like `Registry["entry"]` for use in type
+        annotations.
+        """
+
+        def __init__(
+            cls, name: str, bases: tuple[type, ...], namespace: dict[str, Any]
+        ):
+            super().__init__(name, bases, namespace)
+
+            cls._type_entries: dict[str, Any] = {}
+
+        def __getitem__(cls, schema: type | str) -> Optional[SchemaEntry]:
+            schema_typename = ""
+            if isinstance(schema, str):
+                schema_typename = schema
+            elif isinstance(schema, type):
+                schema_typename = str(schema)
+
+            if not schema_typename:
+                raise TypeError(
+                    f"`{cls.__name__}` annotation must be a schema type or name"
+                )
+
+            return cls._type_entries.get(schema_typename)
+
+        def register(cls, name: str):
+            cls._type_entries[name] = f"SchemaEntry['{name}']"
+
+    class ValRegistryMeta(type):
+        """
+        A metaclass for a registry to support subscript syntax like `Registry["entry"]` and
+        attribute syntax like `Registry.entry`.
+        """
+
+        def __init__(
+            cls, name: str, bases: tuple[type, ...], namespace: dict[str, Any]
+        ):
+            super().__init__(name, bases, namespace)
+
+            cls._val_entries: dict[str, Any] = {}
+
+        def __getattr__(cls, name: str, /) -> Any:
+            """
+            Accessor for a Registry that returns the registered value (defaults to `None`).
+            """
+
+            return cls._val_entries.get(name)
+
+        def register(cls, name: str, entry_val: Optional[Any] = None):
+            cls._val_entries[name] = entry_val
+
+    # Experimental: return types for model tasks
+    class Artifact(pyarrow.Table, metaclass=TypeRegistryMeta):
+        """
+        A registry for artifact schemas. Supports subscript syntax `Artifact["name"]`
+        to reference a schema entry by name.
+        """
+
+        ...
+
+    class Catalog(pyarrow.Table, metaclass=TypeRegistryMeta):
+        """
+        A registry for catalog schemas. Supports subscript syntax `Catalog["name"]`
+        to reference a schema entry by name.
+        """
+
+        ...
+
+    # Experimental: base types for defining table schemas
+    class TableSchemaMeta(type):
+        def __new__(
+            metacls, name: str, bases: tuple[type, ...], namespace: dict[str, Any]
+        ):
+            new_schema_cls = super().__new__(metacls, name, bases, namespace)
+
+            return new_schema_cls
+
+        def __init__(
+            self, name: str, bases: tuple[type, ...], namespace: dict[str, Any]
+        ):
+            super().__init__(name, bases, namespace)
+
+    class TableSchema(metaclass=TableSchemaMeta):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+
+    # Experimental: proxy types for model tasks
+    class ModelTask:
+        """
+        A proxy object representing a model task in a DAG.
+
+        Wraps a decorated model function so that it can be called directly
+        while carrying extra metadata (task name, result schema, etc.).
+        Inspection of the instance (signature, docstring, name) delegates
+        to the wrapped function via ``functools.update_wrapper``.
+        """
+
+        def __init__(
+            self,
+            task_name: str,
+            task_fn: Callable,
+            result_schema: Optional[str] = None,
+        ):
+            self._bpln_task_name = task_name
+            self._bpln_task_fn = task_fn
+            self._bpln_task_api: str = "pyarrow"
+            self._bpln_result_schema = result_schema
+            functools.update_wrapper(self, task_fn)
+
+        def __call__(self, *args: Any, **kwargs: Any) -> Any:
+            return self._bpln_task_fn(*args, **kwargs)
+
+
+else:
+    import warnings
+
+    warnings.warn(
+        "bauplan._contracts: type contract feature "
+        "is not enabled, classes are unavailable",
+        stacklevel=2,
+    )

--- a/python/bauplan/_decorators.py
+++ b/python/bauplan/_decorators.py
@@ -7,7 +7,27 @@ Python environments, with examples of how to use them.
 """
 
 import functools
-from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
+import types
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+)
+
+from bauplan._internal import __bpln_feature_typecontracts__
+
+if __bpln_feature_typecontracts__:
+    # Experimental: support for model task proxies
+    from bauplan._contracts import ModelTask
+else:
+    # A sentinel to satisfy type checker
+    ModelTask = None
+
 
 ModelMaterializationStrategy = Literal[
     "NONE", "REPLACE", "APPEND", "OVERWRITE_PARTITIONS"
@@ -63,11 +83,20 @@ def model(
         overwrite_filter: the overwrite filter expression.
     """
 
-    def decorator(f: Callable) -> Callable:
+    def decorator(f: types.FunctionType) -> Callable:
         @functools.wraps(f)
         def wrapper(*args, **kwargs) -> Any:
             return f(*args, **kwargs)
 
+        # If type contracts are enabled, return a ModelTask instance
+        if __bpln_feature_typecontracts__ and ModelTask:
+            return ModelTask(
+                task_name=f.__name__,
+                task_fn=wrapper,
+                result_schema=f.__annotations__.get("return"),
+            )
+
+        # Otherwise, return the wrapper directly
         return wrapper
 
     return decorator

--- a/python/bauplan/_parameters.py
+++ b/python/bauplan/_parameters.py
@@ -1,7 +1,32 @@
+import logging
+
 from typing import ClassVar
 
+from bauplan._internal import __bpln_feature_typecontracts__
 
-class Parameter:
+if __bpln_feature_typecontracts__:
+    from bauplan._contracts import ValRegistryMeta
+
+
+module_logger = logging.getLogger("bauplan")
+
+
+if __bpln_feature_typecontracts__:
+
+    class ParameterBaseType(metaclass=ValRegistryMeta):
+        """A base type for Parameter if type contracts are enabled."""
+
+        ...
+
+else:
+
+    class ParameterBaseType:
+        """A base type for Parameter if type contracts are disabled."""
+
+        ...
+
+
+class Parameter(ParameterBaseType):  # type: ignore[reportGeneralTypeIssues]
     """
     Represents a parameter that can be used to "template" values
     passed to a model during a run or query with, e.g.,
@@ -44,6 +69,11 @@ class Parameter:
     _requested: ClassVar[set] = set()
 
     def __init__(self, param_name: str) -> None:
+        if __bpln_feature_typecontracts__:
+            module_logger.warning(
+                f'Using deprecated syntax: `Parameter("{param_name}")`'
+            )
+
         Parameter._requested.add(param_name)
 
     def __float__(self) -> float:

--- a/python/tests/test_parameters.py
+++ b/python/tests/test_parameters.py
@@ -1,0 +1,38 @@
+from typing import Any
+
+import pytest
+
+from bauplan._internal import __bpln_feature_typecontracts__
+from bauplan._parameters import Parameter
+
+
+@pytest.mark.skipif(
+    not __bpln_feature_typecontracts__,
+    reason="requires BPLN_ENABLE_TYPE_CONTRACT",
+)
+class TestTypedParameterValueEntry:
+    def test_unregistered_defaults_to_none(self) -> None:
+        assert Parameter.interest_rate is None
+
+    def test_registered_defaults_to_entry_value(self) -> None:
+        Parameter.register("golden_ratio", 1.618)
+        Parameter.register("max_iterations", 100)
+
+        def my_model(
+            golden_ratio: Any = Parameter.golden_ratio,
+            max_iterations: Any = Parameter.max_iterations,
+        ) -> tuple[Any, Any]:
+            return golden_ratio, max_iterations
+
+        assert my_model() == (1.618, 100)
+
+    def test_kwarg_overrides_default(self) -> None:
+        Parameter.register("interest_rate", 5.5)
+
+        def my_model(
+            interest_rate: Any = Parameter.interest_rate,
+            loan_amount: Any = Parameter.loan_amount,
+        ) -> tuple[Any, Any]:
+            return interest_rate, loan_amount
+
+        assert my_model(interest_rate=9.9, loan_amount=200000) == (9.9, 200000)

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -143,7 +143,15 @@ pub(crate) fn job_request_common(
     priority: Option<Priority>,
 ) -> commanderpb::JobRequestCommon {
     let hostname = gethostname::gethostname().to_string_lossy().into_owned();
-    let args = args.into_iter().map(KeyValue::into_strings).collect();
+    let mut args: std::collections::HashMap<String, String> =
+        args.into_iter().map(KeyValue::into_strings).collect();
+
+    if std::env::var("BPLN_ENABLE_TYPE_CONTRACT")
+        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        .unwrap_or(false)
+    {
+        args.insert("enable_type_contracts".to_owned(), "true".to_owned());
+    }
 
     commanderpb::JobRequestCommon {
         module_version: env!("CARGO_PKG_VERSION").to_owned(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -285,3 +285,11 @@ fn read_profile(p: &Path, name: &str) -> Result<ConfigProfile, Error> {
 fn make_ua(product: Option<&str>) -> String {
     format!("{}/{}", product.unwrap_or("default"), env!("BPLN_VERSION"))
 }
+
+/// Returns `true` if the `BPLN_ENABLE_TYPE_CONTRACT` environment variable is
+/// set to a truthy value (`"true"` case-insensitive, or `"1"`).
+pub fn type_contracts_enabled() -> bool {
+    env::var("BPLN_ENABLE_TYPE_CONTRACT")
+        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        .unwrap_or(false)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub mod grpc;
 pub mod project;
 
 pub use api::*;
-pub use config::Profile;
+pub use config::{Profile, type_contracts_enabled};
 pub use refs::*;
 
 #[cfg(feature = "python")]

--- a/src/python.rs
+++ b/src/python.rs
@@ -291,6 +291,12 @@ mod _internal {
             .ok();
 
         m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+        m.add(
+            "__bpln_feature_typecontracts__",
+            std::env::var("BPLN_ENABLE_TYPE_CONTRACT")
+                .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+                .unwrap_or(false),
+        )?;
 
         let sys = m.py().import("sys")?;
         let modules = sys.getattr("modules")?;

--- a/tests/cli/run.rs
+++ b/tests/cli/run.rs
@@ -259,6 +259,55 @@ fn multiparent() {
 //         .stdout(contains("s3write parallel_child_1"));
 // }
 
+// This test will fail until the server is able to install an SDK with the new feature flag.
+#[test]
+#[ignore]
+fn typed_parameters_idempotent() {
+    // The fixture monkey-patches __bpln_feature_typecontracts__ to True, so this
+    // test exercises the typed-parameter code path regardless of the compile-time flag.
+    bauplan()
+        .args([
+            "run",
+            "--cache",
+            "off",
+            "--dry-run",
+            "-p",
+            "tests/fixtures/typed-parameters",
+            "--param",
+            "location_id=123",
+            "--param",
+            "golden_ratio=4.2",
+            "--param",
+            "use_random_forest=false",
+            "--param",
+            "start_datetime=2023-01-01T00:00:00+00:00",
+            "--param",
+            "end_datetime=2023-01-02T00:00:00+00:00",
+        ])
+        .assert()
+        .success()
+        .stderr(contains("yayparams.num_rows=629154"))
+        .stderr(contains("yayparams.num_columns=3"));
+}
+
+#[test]
+fn typed_parameters_feature_flag() {
+    // The old Parameter('name') syntax works in both modes. When type contracts
+    // are enabled, a deprecation warning is emitted but the run still succeeds.
+    let assertion = bauplan()
+        .args([
+            "run",
+            "--cache",
+            "off",
+            "--dry-run",
+            "-p",
+            "tests/fixtures/parameters",
+        ])
+        .assert();
+
+    assertion.success().stderr(contains("golden_ratio=1.666"));
+}
+
 #[test]
 fn parameters_project() {
     bauplan()

--- a/tests/fixtures/typed-parameters/bauplan_project.yml
+++ b/tests/fixtures/typed-parameters/bauplan_project.yml
@@ -1,0 +1,24 @@
+project:
+  id: 641d33d8-a6c2-4525-90d5-d54e7f27c36f
+  name: parameters_are_cool
+
+defaults:
+  python:
+    version: "3.11"
+
+parameters:
+  location_id:
+    default: 138
+    type: int
+  golden_ratio:
+    default: 1.666
+    type: float
+  use_random_forest:
+    default: True
+    type: bool
+  start_datetime:
+    default: "2023-01-01T00:00:00+00:00"
+    type: str
+  end_datetime:
+    default: "2023-01-03T00:00:00+00:00"
+    type: str

--- a/tests/fixtures/typed-parameters/models.py
+++ b/tests/fixtures/typed-parameters/models.py
@@ -1,0 +1,43 @@
+# Force the type-contracts feature on regardless of the compile-time flag,
+# so that this fixture can be used as an idempotent test.
+# Must be set before bauplan._internal is imported.
+import os
+
+os.environ['BPLN_ENABLE_TYPE_CONTRACT'] = 'True'
+
+import bauplan
+import pyarrow as pa
+
+from bauplan import Parameter
+
+
+@bauplan.model(
+    columns=['y'],
+    materialization_strategy='NONE',
+)
+@bauplan.python('3.13')
+def typed_params_model(
+    yayparams=bauplan.Model(  # noqa: B008, ANN001
+        'query_model',
+        columns=[
+            'dropoff_datetime',
+            'pickup_datetime',
+            'trip_miles',
+        ],
+        filter='PULocationID = $location_id',
+    ),
+    golden_ratio=Parameter.golden_ratio,
+    use_random_forest=Parameter.use_random_forest,
+    start_datetime=Parameter.start_datetime,
+    end_datetime=Parameter.end_datetime,
+) -> pa.Table:
+    print(f'golden_ratio={golden_ratio}')
+    print(f'use_random_forest={use_random_forest}')
+    print(f'start_datetime={start_datetime}')
+    print(f'end_datetime={end_datetime}')
+
+    print(yayparams)
+    print(f'yayparams.num_rows={yayparams.num_rows}')
+    print(f'yayparams.num_columns={yayparams.num_columns}')
+
+    return pa.Table.from_pydict({'y': [1, 2, 3]})

--- a/tests/fixtures/typed-parameters/query_model.sql
+++ b/tests/fixtures/typed-parameters/query_model.sql
@@ -1,0 +1,17 @@
+-- bauplan: materialization_strategy = NONE
+SELECT
+    pickup_datetime,
+    dropoff_datetime,
+    PULocationID,
+    DOLocationID,
+    trip_miles,
+    trip_time,
+    base_passenger_fare,
+    tolls,
+    sales_tax,
+    tips
+FROM
+    taxi_fhvhv
+WHERE
+    pickup_datetime >= $start_datetime
+AND pickup_datetime < $end_datetime


### PR DESCRIPTION
This is a PR to add support for type contracts.

The intention is for new syntax to be gated behind a feature flag (`__bpln_feature_typecontracts__`). The new syntax does not "do" much, meaning that at runtime the new syntax should be functional:

* `Parameter` will return `None` if there's no value associated with the requested parameter
* `ModelTask` (functions decorated with `@bauplan.model`) can still be invoked in the usual way and have all of the usual metadata set (the function wrapper inherits the decorated function's metadata, etc.)

The caveat with `ModelTask` is that because it assigns the decorated function to the `__call__` method of the `ModelTask` proxy object, it won't inspect the same way as a pure function (but you can inspect the `__call__` method and it should be the same).

The goal is to add some logic and structures into the SDK that can be leveraged at runtime or at least adds support for new syntax that can be parsed. This should not affect how the SDK is used today and it should not have significant impact on existing code even if the new syntax is adopted (everything should be transparent).