### PR TITLE
fix: enable ureq platform-verifier on all platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,13 +107,10 @@ tonic-prost = "0.14"
 tracing = { workspace = true, features = ["log"] }
 tracing-indicatif = "0.3"
 tracing-subscriber = { version = "0.3", features = ["chrono", "env-filter"] }
-ureq = "3"
+ureq = { version = "3", features = ["platform-verifier"] }
 url.workspace = true
 uuid = { version = "1", features = ["serde", "v4"] }
 zip = { version = "4", default-features = false, features = ["deflate"] }
-
-[target.'cfg(target_os = "macos")'.dependencies]
-ureq = { version = "3", features = ["platform-verifier"] }
 
 [build-dependencies]
 anyhow = "1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -207,17 +207,13 @@ pub(crate) fn run(args: Args, multiprogress: indicatif::MultiProgress) -> anyhow
     profile.validate()?;
 
     // Allows error responses to be parsed.
-    let mut cfg = ureq::config::Config::builder().http_status_as_error(false);
-    // Trust macOS Keychain CAs in dev builds so devs can use Keychain-managed
-    // certs (e.g. mkcert) without extra setup.
-    #[cfg(all(debug_assertions, target_os = "macos"))]
-    {
-        cfg = cfg.tls_config(
+    let mut cfg = ureq::config::Config::builder()
+        .http_status_as_error(false)
+        .tls_config(
             ureq::tls::TlsConfig::builder()
                 .root_certs(ureq::tls::RootCerts::PlatformVerifier)
                 .build(),
         );
-    }
     let timeout = match args.global.client_timeout {
         Some(-1) | None => None,
         Some(v) if v > 0 => Some(time::Duration::from_secs(v as _)),

--- a/src/python.rs
+++ b/src/python.rs
@@ -202,18 +202,14 @@ impl Client {
             .map(time::Duration::from_secs)
             .unwrap_or(time::Duration::from_secs(30));
 
-        let mut cfg = ureq::config::Config::builder().http_status_as_error(false);
-        // Trust macOS Keychain CAs in dev builds so devs can use Keychain-managed
-        // certs (e.g. mkcert) without extra setup.
-        #[cfg(all(debug_assertions, target_os = "macos"))]
-        {
-            cfg = cfg.tls_config(
+        let cfg = ureq::config::Config::builder()
+            .http_status_as_error(false)
+            .tls_config(
                 ureq::tls::TlsConfig::builder()
                     .root_certs(ureq::tls::RootCerts::PlatformVerifier)
                     .build(),
-            );
-        }
-        cfg = cfg.timeout_global(Some(client_timeout));
+            )
+            .timeout_global(Some(client_timeout));
         let agent = ureq::Agent::new_with_config(cfg.build());
 
         let grpc = {


### PR DESCRIPTION
Use the OS trust store for ureq HTTPS calls so locally-trusted
certs (e.g. mkcert) are honored when testing against local services.

tonic already trusts OS native roots via tls-native-roots in
src/grpc.rs. this aligns ureq with the same behavior.

From the rustls-platform-verifier README [1]:

> It is the opinion of the rustls and rustls-platform-verifier
> teams that this is the best default available for client-side
> libraries and applications making connections to TLS servers
> when running on common operating systems. This is because it
> gets both live trust information (new roots, explicit markers,
> and auto-managed CRLs) and better matches the common
> expectation of apps running on that platform (to use proxies,
> for example). Otherwise, it becomes your maintenance burden to
> ship updates right away in order to handle increasing numbers
> of positive and negative trust events in the WebPKI/certificate
> ecosystem, or risk availability and security concerns.

[1]: https://github.com/rustls/rustls-platform-verifier
