### PR TITLE
feat: remove BPLN_USERNAME env variable

### DIFF
--- a/src/api/testutil.rs
+++ b/src/api/testutil.rs
@@ -31,7 +31,7 @@ pub(crate) fn roundtrip<T: ApiRequest>(req: T) -> Result<T::Response, ApiError> 
 
 /// Get the username for the test profile via the gRPC info endpoint.
 pub(crate) fn test_username() -> &'static str {
-    use crate::grpc::{self, generated::GetBauplanInfoRequest};
+    use crate::grpc;
 
     static USERNAME: OnceLock<String> = OnceLock::new();
     USERNAME.get_or_init(|| {
@@ -43,15 +43,7 @@ pub(crate) fn test_username() -> &'static str {
             let mut client = grpc::Client::new_lazy(profile, time::Duration::from_secs(30))
                 .expect("Failed to create gRPC client");
 
-            let resp = client
-                .get_bauplan_info(GetBauplanInfoRequest::default())
-                .await
-                .expect("Failed to get bauplan info");
-
-            resp.into_inner()
-                .user_info
-                .expect("No user info in response")
-                .username
+            client.username().await.expect("Failed to get username")
         })
     })
 }

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -81,6 +81,20 @@ impl Client {
         }
     }
 
+    /// Returns the username associated with the current API key.
+    pub async fn username(&mut self) -> Result<String, tonic::Status> {
+        let resp = self
+            .get_bauplan_info(GetBauplanInfoRequest::default())
+            .await?
+            .into_inner();
+
+        let Some(user_info) = resp.user_info else {
+            return Err(tonic::Status::not_found("no user info in response"))
+        };
+
+        Ok(user_info.username)
+    }
+
     /// Fetches the organization-wide default public key, along with the key name
     /// (usually the ARN).
     pub async fn org_default_public_key(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -28,8 +28,22 @@ pub fn bauplan() -> assert_cmd::Command {
     cmd
 }
 
-pub fn username() -> String {
-    std::env::var("BPLN_USERNAME").unwrap_or_else(|_| "bauplan-e2e-check".to_string())
+pub fn username() -> &'static str {
+    use std::sync::OnceLock;
+
+    static USERNAME: OnceLock<String> = OnceLock::new();
+    USERNAME.get_or_init(|| {
+        let profile = bauplan::Profile::from_default_env()
+            .expect("Failed to load test profile. Did you forget to set BAUPLAN_PROFILE?");
+
+        let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
+        rt.block_on(async {
+            let mut client =
+                bauplan::grpc::Client::new_lazy(&profile, std::time::Duration::from_secs(30))
+                    .expect("Failed to create gRPC client");
+            client.username().await.expect("Failed to get username")
+        })
+    })
 }
 
 pub fn test_branch(suffix: &str) -> TestBranch {


### PR DESCRIPTION
This removes the need for the BPLN_USERNAME env variable by querying for the username of the active profile when needed.