### PR TITLE
feat: add nested SQL

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,3 +33,16 @@ jobs:
         env:
           BAUPLAN_API_ENDPOINT: https://api.use1.aqa.bauplanlabs.com
           BAUPLAN_API_KEY: ${{ secrets.BAUPLAN_API_KEY }}
+
+  # Test path handling on windows, but don't bother with the entire integration test suite.
+  test-windows:
+    name: Unit Tests (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: ./.github/actions/setup-caches
+
+      - run: mise x -- cargo test --lib

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,10 +665,12 @@ dependencies = [
  "escargot",
  "futures",
  "gethostname",
+ "globset",
  "http",
  "http-body-util",
  "humantime",
  "iceberg-catalog-rest",
+ "ignore",
  "indicatif",
  "log",
  "nondestructive",
@@ -2631,9 +2633,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
 dependencies = [
  "crossbeam-deque",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,8 @@ ureq = { version = "3", features = ["platform-verifier"] }
 url.workspace = true
 uuid = { version = "1", features = ["serde", "v4"] }
 zip = { version = "4", default-features = false, features = ["deflate"] }
+globset = "0.4.18"
+ignore = "0.4.26"
 tokio-util = { version = "0.7.18", features = ["codec"] }
 
 [build-dependencies]

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -53,6 +53,7 @@ pub(crate) fn handle(args: InitArgs) -> anyhow::Result<()> {
             description: None,
         },
         parameters: Default::default(),
+        include_paths: Vec::new(),
         path: Default::default(), // unused
     };
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,8 +1,8 @@
 //! Helpers for managing bauplan projects.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::io::{Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use base64::Engine;
 use rsa::sha2::Sha256;
@@ -10,6 +10,9 @@ use rsa::{Oaep, RsaPublicKey};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
+
+use globset::{Glob, GlobSetBuilder};
+use ignore::WalkBuilder;
 
 /// Errors that can occur when working with project files.
 #[derive(Debug, Error)]
@@ -27,6 +30,16 @@ pub enum ProjectError {
     Zip(#[from] zip::result::ZipError),
     #[error("encryption failed")]
     Encryption(#[from] rsa::Error),
+    #[error("invalid glob pattern")]
+    Glob(#[from] globset::Error),
+    #[error("failed to resolve include paths")]
+    Ignore(#[from] ignore::Error),
+    #[error("glob pattern not allowed: {0}")]
+    GlobPatternNotAllowed(String),
+    #[error("symlink not allowed: {0} points to {1}")]
+    Symlink(PathBuf, PathBuf),
+    #[error("failed to extract relative path")]
+    Prefix(#[from] std::path::StripPrefixError),
     #[error("invalid value {0:?} of type {1}")]
     InvalidParameterValue(String, ParameterType),
 }
@@ -256,6 +269,12 @@ pub struct ProjectFile {
     /// Parameters for models.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub parameters: BTreeMap<String, ParameterDefault>,
+    // /// Additional paths to include as glob expressions.
+    // #[serde(default, skip_serializing_if = "Option::is_none")]
+    // pub include_paths: Option<Vec<String>>,
+    /// Additional paths to include as glob expressions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub include_paths: Vec<String>,
 
     /// The location of the project file on disk.
     #[serde(skip)]
@@ -302,27 +321,33 @@ impl ProjectFile {
             )
         })?;
 
+        // Additional, user-provided patterns.
+        let additional_patterns = self
+            .include_paths
+            .iter()
+            .map(|p| resolve_pattern(p))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let files: HashSet<PathBuf> =
+            resolve_includes(project_dir, &additional_patterns)?.collect();
+
         let mut buf = Vec::new();
         let mut zip = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
         let options = zip::write::SimpleFileOptions::default()
             .compression_method(zip::CompressionMethod::Deflated);
 
         let mut contents = Vec::new();
-        for entry in std::fs::read_dir(project_dir)? {
-            let path = entry?.path();
-            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-                continue;
-            };
-
-            if !include_in_snapshot(name) {
-                continue;
-            }
+        for path in files {
+            // The zip spec mandates forward slashes in entry names, and serializing
+            // the Path would produce backslashes on Windows; start_file_from_path
+            // does the conversion.
+            let name = path.strip_prefix(project_dir)?;
 
             contents.clear();
             let mut file = std::fs::File::open(&path)?;
             file.read_to_end(&mut contents)?;
 
-            zip.start_file(name, options)?;
+            zip.start_file_from_path(name, options)?;
             zip.write_all(&contents)?;
         }
 
@@ -331,10 +356,132 @@ impl ProjectFile {
     }
 }
 
-fn include_in_snapshot(name: &str) -> bool {
-    name.ends_with(".py")
-        || name.ends_with(".sql")
-        || name == "requirements.txt"
-        || name == "bauplan_project.yml"
-        || name == "bauplan_project.yaml"
+/// Given a glob pattern, ensure the pattern is "admissible".
+fn resolve_pattern(p: &str) -> Result<String, ProjectError> {
+    // Users should be explicitly including file extensions, not globbing for all files.
+    if !p.ends_with(".sql") {
+        return Err(ProjectError::GlobPatternNotAllowed(p.to_string()));
+    }
+
+    // Absolute patterns are not allowed, only relative.
+    let pattern = Path::new(p);
+    if pattern.is_absolute() {
+        return Err(ProjectError::GlobPatternNotAllowed(format!(
+            "{} is an absolute path",
+            p
+        )));
+    }
+
+    // Patterns with ".." are not allowed.
+    if pattern
+        .components()
+        .any(|c| matches!(c, Component::ParentDir))
+    {
+        return Err(ProjectError::GlobPatternNotAllowed(p.to_string()));
+    }
+
+    // Strip leading ./ and use forward slashes for glob syntax.
+    Ok(p.strip_prefix("./").unwrap_or(p).replace('\\', "/"))
+}
+
+/// Include files in snapshot, based on provided glob patterns.
+/// Ignoring takes precedence over inclusion: any ignored file will not be included
+/// regardless of inclusion patterns.
+fn resolve_includes<S: AsRef<str>>(
+    base: &Path,
+    patterns: &[S],
+) -> Result<impl Iterator<Item = PathBuf>, ProjectError> {
+    let base_canonical = base.canonicalize()?;
+
+    // Build a glob set, matching all the required patterns.
+    let mut glob_builder = GlobSetBuilder::new();
+
+    // Top level patterns, always included.
+    let base_patterns = [
+        "*.py",
+        "*.sql",
+        "requirements.txt",
+        "bauplan_project.yml",
+        "bauplan_project.yaml",
+    ];
+
+    for p in patterns {
+        glob_builder.add(Glob::new(p.as_ref())?);
+    }
+
+    for p in base_patterns {
+        glob_builder.add(Glob::new(p).unwrap());
+    }
+
+    let set = glob_builder.build()?;
+
+    let mut paths = BTreeSet::new();
+
+    for entry in WalkBuilder::new(&base_canonical).build() {
+        let entry = entry?.into_path();
+        let canonical = entry.canonicalize()?;
+
+        if !canonical.is_file() {
+            continue;
+        }
+
+        let rel_entry = canonical
+            .strip_prefix(&base_canonical)
+            .map_err(|_| ProjectError::Symlink(entry, canonical.clone()))?
+            .to_path_buf();
+
+        // For globset to work, we need relative paths.
+        if !set.is_match(&rel_entry) {
+            continue;
+        }
+
+        // For zipping to work, we need absolute paths.
+        paths.insert(canonical);
+    }
+
+    Ok(paths.into_iter())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_pattern_rejects_upward_pattern() {
+        let tmp = tempfile::tempdir().unwrap();
+        let proj = tmp.path().join("proj");
+        std::fs::create_dir_all(proj.join("views")).unwrap();
+        std::fs::write(proj.join("views").join("age.sql"), "SELECT 1").unwrap();
+
+        let result = resolve_pattern("../proj/views/*.sql");
+        assert!(matches!(
+            result,
+            Err(ProjectError::GlobPatternNotAllowed(..))
+        ));
+    }
+
+    fn symlink_file(src: &Path, dst: &Path) {
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(src, dst).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(src, dst).unwrap();
+    }
+
+    #[test]
+    fn resolve_includes_rejects_symlink_escaping_base() {
+        let tmp = tempfile::tempdir().unwrap();
+        let proj = tmp.path().join("proj");
+        std::fs::create_dir_all(proj.join("views")).unwrap();
+
+        std::fs::write(tmp.path().join("secret.sql"), "SELECT secret").unwrap();
+
+        symlink_file(
+            &tmp.path().join("secret.sql"),
+            &proj.join("views").join("leak.sql"),
+        );
+
+        let patterns = &[resolve_pattern("views/*.sql").unwrap()];
+        let result = resolve_includes(&proj, patterns);
+        assert!(matches!(result, Err(ProjectError::Symlink(..))));
+    }
 }

--- a/tests/cli/run.rs
+++ b/tests/cli/run.rs
@@ -490,3 +490,66 @@ fn with_transaction() {
         .success()
         .stderr(contains("num_rows= 430488"));
 }
+
+#[test]
+fn sql_nested() {
+    bauplan()
+        .args([
+            "run",
+            "--dry-run",
+            "--cache",
+            "off",
+            "-p",
+            "tests/fixtures/sql_nested",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn sql_prohibited_upward() {
+    bauplan()
+        .args([
+            "run",
+            "--dry-run",
+            "--cache",
+            "off",
+            "-p",
+            "tests/fixtures/sql_prohibited_upward/pipeline",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("glob pattern not allowed"));
+}
+
+#[test]
+fn sql_prohibited_pattern() {
+    bauplan()
+        .args([
+            "run",
+            "--dry-run",
+            "--cache",
+            "off",
+            "-p",
+            "tests/fixtures/sql_prohibited_pattern",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("glob pattern not allowed"));
+}
+
+#[test]
+fn sql_prohibited_extension() {
+    bauplan()
+        .args([
+            "run",
+            "--dry-run",
+            "--cache",
+            "off",
+            "-p",
+            "tests/fixtures/sql_prohibited_extension",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("glob pattern not allowed"));
+}

--- a/tests/fixtures/sql_nested/bauplan_project.yaml
+++ b/tests/fixtures/sql_nested/bauplan_project.yaml
@@ -1,0 +1,6 @@
+project:
+  id: 97e33cab-6805-4565-9df3-8ffa5e914574
+  name: sql_nested
+include_paths:
+  - views/*.sql
+  - views/**/*.sql

--- a/tests/fixtures/sql_nested/models.py
+++ b/tests/fixtures/sql_nested/models.py
@@ -1,0 +1,25 @@
+import bauplan
+
+
+@bauplan.python("3.12", pip={"polars": "1.37"})
+@bauplan.model()
+def check_age_in_views(data=bauplan.Model("age")):
+
+    import polars as pl  # noqa
+
+    df = pl.from_arrow(data)
+    assert df["n_nulls_age"][0] == 177
+
+    return df.to_arrow()
+
+
+@bauplan.python("3.12", pip={"polars": "1.37"})
+@bauplan.model()
+def check_age_in_views_nested(data=bauplan.Model("age_nulls")):
+
+    import polars as pl  # noqa
+
+    df = pl.from_arrow(data)
+    assert df["n_nulls_age"][0] == 177
+
+    return df.to_arrow()

--- a/tests/fixtures/sql_nested/pyproject.toml
+++ b/tests/fixtures/sql_nested/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "nested_sql"
+requires-python = "~=3.12"
+dependencies = ["bauplan~=0.1.11"]

--- a/tests/fixtures/sql_nested/views/age.sql
+++ b/tests/fixtures/sql_nested/views/age.sql
@@ -1,0 +1,1 @@
+SELECT COUNT(*) - COUNT(Age) AS n_nulls_age FROM titanic

--- a/tests/fixtures/sql_nested/views/nested/age.sql
+++ b/tests/fixtures/sql_nested/views/nested/age.sql
@@ -1,0 +1,2 @@
+-- bauplan: name=age_nulls
+SELECT COUNT(*) - COUNT(Age) AS n_nulls_age FROM titanic

--- a/tests/fixtures/sql_prohibited_extension/bauplan_project.yaml
+++ b/tests/fixtures/sql_prohibited_extension/bauplan_project.yaml
@@ -1,0 +1,6 @@
+project:
+  id: 97e33cab-6805-4565-9df3-8ffa5e914574
+  name: sql_nested
+include_paths:
+  - views/*.py
+  - views/**/*.sql

--- a/tests/fixtures/sql_prohibited_extension/models.py
+++ b/tests/fixtures/sql_prohibited_extension/models.py
@@ -1,0 +1,25 @@
+import bauplan
+
+
+@bauplan.python("3.12", pip={"polars": "1.37"})
+@bauplan.model()
+def check_age_in_views(data=bauplan.Model("age")):
+
+    import polars as pl  # noqa
+
+    df = pl.from_arrow(data)
+    assert df["n_nulls_age"][0] == 177
+
+    return df.to_arrow()
+
+
+@bauplan.python("3.12", pip={"polars": "1.37"})
+@bauplan.model()
+def check_age_in_views_nested(data=bauplan.Model("age_nulls")):
+
+    import polars as pl  # noqa
+
+    df = pl.from_arrow(data)
+    assert df["n_nulls_age"][0] == 177
+
+    return df.to_arrow()

--- a/tests/fixtures/sql_prohibited_extension/pyproject.toml
+++ b/tests/fixtures/sql_prohibited_extension/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "nested_sql"
+requires-python = "~=3.12"
+dependencies = ["bauplan~=0.1.11"]

--- a/tests/fixtures/sql_prohibited_extension/views/age.sql
+++ b/tests/fixtures/sql_prohibited_extension/views/age.sql
@@ -1,0 +1,1 @@
+SELECT COUNT(*) - COUNT(Age) AS n_nulls_age FROM titanic

--- a/tests/fixtures/sql_prohibited_extension/views/nested/age.sql
+++ b/tests/fixtures/sql_prohibited_extension/views/nested/age.sql
@@ -1,0 +1,2 @@
+-- bauplan: name=age_nulls
+SELECT COUNT(*) - COUNT(Age) AS n_nulls_age FROM titanic

--- a/tests/fixtures/sql_prohibited_pattern/bauplan_project.yaml
+++ b/tests/fixtures/sql_prohibited_pattern/bauplan_project.yaml
@@ -1,0 +1,5 @@
+project:
+  id: 97e33cab-6805-4565-9df3-8ffa5e914574
+  name: sql_nested
+include_paths:
+  - views/*

--- a/tests/fixtures/sql_prohibited_pattern/models.py
+++ b/tests/fixtures/sql_prohibited_pattern/models.py
@@ -1,0 +1,25 @@
+import bauplan
+
+
+@bauplan.python("3.12", pip={"polars": "1.37"})
+@bauplan.model()
+def check_age_in_views(data=bauplan.Model("age")):
+
+    import polars as pl  # noqa
+
+    df = pl.from_arrow(data)
+    assert df["n_nulls_age"][0] == 177
+
+    return df.to_arrow()
+
+
+@bauplan.python("3.12", pip={"polars": "1.37"})
+@bauplan.model()
+def check_age_in_views_nested(data=bauplan.Model("age_nulls")):
+
+    import polars as pl  # noqa
+
+    df = pl.from_arrow(data)
+    assert df["n_nulls_age"][0] == 177
+
+    return df.to_arrow()

--- a/tests/fixtures/sql_prohibited_pattern/pyproject.toml
+++ b/tests/fixtures/sql_prohibited_pattern/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "nested_sql"
+requires-python = "~=3.12"
+dependencies = ["bauplan~=0.1.11"]

--- a/tests/fixtures/sql_prohibited_pattern/views/age.sql
+++ b/tests/fixtures/sql_prohibited_pattern/views/age.sql
@@ -1,0 +1,1 @@
+SELECT COUNT(*) - COUNT(Age) AS n_nulls_age FROM titanic

--- a/tests/fixtures/sql_prohibited_upward/age.sql
+++ b/tests/fixtures/sql_prohibited_upward/age.sql
@@ -1,0 +1,1 @@
+SELECT COUNT(*) - COUNT(Age) AS n_nulls_age FROM titanic

--- a/tests/fixtures/sql_prohibited_upward/pipeline/bauplan_project.yaml
+++ b/tests/fixtures/sql_prohibited_upward/pipeline/bauplan_project.yaml
@@ -1,0 +1,5 @@
+project:
+  id: 97e33cab-6805-4565-9df3-8ffa5e914574
+  name: sql_prohibited
+include_paths:
+  - ../*.sql

--- a/tests/fixtures/sql_prohibited_upward/pipeline/models.py
+++ b/tests/fixtures/sql_prohibited_upward/pipeline/models.py
@@ -1,0 +1,13 @@
+import bauplan
+
+
+@bauplan.python("3.12", pip={"polars": "1.37"})
+@bauplan.model()
+def check_age_in_views(data=bauplan.Model("age")):
+
+    import polars as pl  # noqa
+
+    df = pl.from_arrow(data)
+    assert df["n_nulls_age"][0] == 177
+
+    return df.to_arrow()

--- a/tests/fixtures/sql_prohibited_upward/pipeline/pyproject.toml
+++ b/tests/fixtures/sql_prohibited_upward/pipeline/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "sql_prohibited"
+requires-python = "~=3.12"
+dependencies = ["bauplan~=0.1.11"]


### PR DESCRIPTION
This PR allows users to extend a `bauplan_project.yml` with an additional parameter `include_paths`. 
`include_paths` is a list of (relative) glob patterns which will trigger the inclusion of SQL files _only_ in the code snapshot. 

Current limitations:
- Only SQL files can be included (no Python, or others)
- Research can only happen "downward" from the Bauplan project directory; upward search is prohibited.
- Gitignored files are ignored, regardless of them being included in `include_paths`. 

Loud failure modes:
1. Pattern does not end with `.sql` (_not_ case sensitive);
2. Pattern is absolute and not relative;
3. Pattern points outside project directory;
4. Patterns including `..` are not allowed;
5. Non UTF-8 patterns;
7. File extension is not `.sql` (case sensitive);
8. File is a symlink pointing outside the project directory. 

Tested on Windows & MacOS