### PR TITLE
docs: wire GTAG_ID into docs builds

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -74,6 +74,7 @@ jobs:
         working-directory: ./docs
         env:
           DOCS_URL: ${{ vars.DOCS_URL }}
+          GTAG_ID: ${{ vars.GTAG_ID }}
         run: just build /tmp/build
 
       # Run typechecking after building, so that it also checks the generated mdx files.


### PR DESCRIPTION
As per @mapav19's request, adding the google tag. The gtag id wasn't passed to the build before. This pr fixes it.