### PR TITLE
feat(longbow): bump iroh to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,15 +549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,10 +627,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base32"
-version = "0.5.1"
+name = "base16ct"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -693,7 +684,7 @@ dependencies = [
  "pyo3-log",
  "rand 0.8.6",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "resolve-path",
  "rsa",
  "serde",
@@ -736,8 +727,8 @@ dependencies = [
  "bytes",
  "futures",
  "iroh",
- "n0-error",
- "rand 0.9.4",
+ "n0-error 0.1.3",
+ "rustls",
  "test-log",
  "thiserror 2.0.18",
  "tokio",
@@ -797,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
 ]
@@ -935,6 +926,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1009,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -1119,6 +1127,16 @@ checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
 dependencies = [
  "loom",
  "tracing",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1261,17 +1279,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "5.0.0-pre.1"
+name = "ctutils"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9200d1d13637f15a6acb71e758f64624048d85b31a5fdbfd8eca1e2687d0b7"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest 0.11.0-rc.10",
+ "digest 0.11.3",
  "fiat-crypto",
- "rand_core 0.9.5",
+ "rand_core 0.10.1",
  "rustc_version",
  "serde",
  "subtle",
@@ -1363,6 +1390,26 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
+dependencies = [
+ "data-encoding",
+ "syn",
+]
 
 [[package]]
 name = "dateparser"
@@ -1498,11 +1545,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.10"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa94b64bfc6549e6e4b5a3216f22593224174083da7a90db47e951c4fb31725"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.11.0",
+ "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.1",
 ]
@@ -1558,22 +1605,13 @@ checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
 
 [[package]]
 name = "dlopen2"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b4f5f101177ff01b8ec4ecc81eead416a8aa42819a2869311b3420fa114ffa"
+checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
 dependencies = [
  "libc",
  "once_cell",
  "winapi",
-]
-
-[[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
 ]
 
 [[package]]
@@ -1584,27 +1622,27 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8 0.11.0-rc.11",
- "serde",
- "signature 3.0.0-rc.10",
+ "pkcs8 0.11.0",
+ "serdect",
+ "signature 3.0.0",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.1"
+version = "3.0.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad207ed88a133091f83224265eac21109930db09bedcad05d5252f2af2de20a1"
+checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.9.5",
+ "rand_core 0.10.1",
  "serde",
- "sha2 0.11.0-rc.2",
- "signature 3.0.0-rc.10",
+ "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -1632,18 +1670,6 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "enum-assoc"
@@ -1744,18 +1770,6 @@ checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
 dependencies = [
  "dissimilar",
  "once_cell",
-]
-
-[[package]]
-name = "fastbloom"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
-dependencies = [
- "getrandom 0.3.4",
- "libm",
- "rand 0.9.4",
- "siphasher",
 ]
 
 [[package]]
@@ -2037,6 +2051,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -2120,15 +2135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,30 +2154,16 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
 
 [[package]]
 name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version",
- "serde",
- "spin 0.9.8",
- "stable_deref_trait",
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2187,26 +2179,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "bytes",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
  "h2",
+ "hickory-proto",
  "http",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
+ "jni 0.22.4",
+ "rand 0.10.1",
  "rustls",
  "thiserror 2.0.18",
  "tinyvec",
@@ -2217,22 +2208,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.1",
  "resolv-conf",
  "rustls",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
@@ -2434,7 +2450,7 @@ dependencies = [
  "ordered-float 4.6.0",
  "parquet",
  "rand 0.9.4",
- "reqwest",
+ "reqwest 0.12.28",
  "roaring",
  "serde",
  "serde_bytes",
@@ -2462,7 +2478,7 @@ dependencies = [
  "http",
  "iceberg",
  "itertools 0.13.0",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2594,11 +2610,10 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.16.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
+checksum = "de7238d487a9aff61f81b5ab41c0a841532a115a398b5fa92a2fadd0885e2581"
 dependencies = [
- "async-trait",
  "attohttpc",
  "bytes",
  "futures",
@@ -2607,7 +2622,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.9.4",
+ "rand 0.10.1",
  "tokio",
  "url",
  "xmltree",
@@ -2708,6 +2723,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -2721,25 +2739,28 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "0.97.0"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb56e7e4b0ec7fba7efa6a236b016a52b5d927d50244aceb9e20566159b1a32"
+checksum = "bef865dc2d11a19fe670ff217b68ffc3b511bddf473dc3a3e120090b9f691803"
 dependencies = [
  "backon",
+ "blake3",
  "bytes",
  "cfg_aliases",
+ "ctutils",
  "data-encoding",
  "derive_more",
  "ed25519-dalek",
  "futures-util",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "hickory-resolver",
  "http",
  "ipnet",
  "iroh-base",
+ "iroh-dns",
  "iroh-metrics",
  "iroh-relay",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "n0-future",
  "n0-watcher",
  "netwatch",
@@ -2748,12 +2769,10 @@ dependencies = [
  "noq-udp",
  "papaya",
  "pin-project",
- "pkarr",
- "pkcs8 0.11.0-rc.11",
  "portable-atomic",
  "portmapper",
- "rand 0.9.4",
- "reqwest",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
@@ -2761,7 +2780,6 @@ dependencies = [
  "serde",
  "smallvec",
  "strum 0.28.0",
- "sync_wrapper",
  "time",
  "tokio",
  "tokio-stream",
@@ -2774,35 +2792,60 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "0.97.0"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a354e3396b62c14717ee807dfee9a7f43f6dad47e4ac0fd1d49f1ffad14ef0"
+checksum = "af93d67701c00c504982154569192ad384738c0450ba1196930314b955100552"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
+ "data-encoding-macro",
  "derive_more",
- "digest 0.11.0-rc.10",
+ "digest 0.11.3",
  "ed25519-dalek",
- "n0-error",
- "rand_core 0.9.5",
+ "getrandom 0.4.2",
+ "n0-error 1.0.0-rc.0",
+ "rand 0.10.1",
  "serde",
- "sha2 0.11.0-rc.2",
+ "sha2 0.11.0",
  "url",
  "zeroize",
  "zeroize_derive",
 ]
 
 [[package]]
-name = "iroh-metrics"
-version = "0.38.3"
+name = "iroh-dns"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761b45ba046134b11eb3e432fa501616b45c4bf3a30c21717578bc07aa6461dd"
+checksum = "de4112c91eb64094d77df9d3112606dcf7ff216421afccd2dc762fda5a7b2879"
+dependencies = [
+ "arc-swap",
+ "cfg_aliases",
+ "derive_more",
+ "hickory-resolver",
+ "iroh-base",
+ "n0-error 1.0.0-rc.0",
+ "n0-future",
+ "ndk-context",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "rustls",
+ "simple-dns",
+ "strum 0.28.0",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "iroh-metrics"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d102597d0ee523f17fdb672c532395e634dbe945429284c811430d63bacc0d8a"
 dependencies = [
  "iroh-metrics-derive",
  "itoa",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "portable-atomic",
- "postcard",
  "ryu",
  "serde",
  "tracing",
@@ -2810,9 +2853,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics-derive"
-version = "0.4.1"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab063c2bfd6c3d5a33a913d4fdb5252f140db29ec67c704f20f3da7e8f92dbf"
+checksum = "91c8e0c97f1dc787107f388433c349397c565572fe6406d600ff7bb7b7fe3b30"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2822,34 +2865,34 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "0.97.0"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d786b260cadfe82ae0b6a9e372e8c78949096a06c857d1c3521355cefced0f55"
+checksum = "a70030b9e71c1183bd4f88fbdbebfa1af2a5be549dd6f20a1e8ac3cd0202ee9d"
 dependencies = [
  "blake3",
  "bytes",
  "cfg_aliases",
  "data-encoding",
  "derive_more",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "hickory-resolver",
  "http",
  "http-body-util",
  "hyper",
  "hyper-util",
  "iroh-base",
+ "iroh-dns",
  "iroh-metrics",
  "lru",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "n0-future",
  "noq",
  "noq-proto",
  "num_enum",
  "pin-project",
- "pkarr",
  "postcard",
- "rand 0.9.4",
- "reqwest",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -2864,7 +2907,6 @@ dependencies = [
  "vergen-gitcl",
  "webpki-roots",
  "ws_stream_wasm",
- "z32",
 ]
 
 [[package]]
@@ -2911,6 +2953,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -3069,12 +3141,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,11 +3170,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -3228,7 +3294,17 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4782b4baf92d686d161c15460c83d16ebcfd215918763903e9619842665cae"
 dependencies = [
- "n0-error-macros",
+ "n0-error-macros 0.1.3",
+ "spez",
+]
+
+[[package]]
+name = "n0-error"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
+dependencies = [
+ "n0-error-macros 1.0.0-rc.0",
  "spez",
 ]
 
@@ -3237,6 +3313,17 @@ name = "n0-error-macros"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03755949235714b2b307e5ae89dd8c1c2531fb127d9b8b7b4adf9c876cd3ed18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "n0-error-macros"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "565305a21e6b3bf26640ad98f05a0fda12d3ab4315394566b52a7bddb8b34828"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3266,12 +3353,12 @@ dependencies = [
 
 [[package]]
 name = "n0-watcher"
-version = "0.6.1"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38795f7932e6e9d1c6e989270ef5b3ff24ebb910e2c9d4bed2d28d8bae3007dc"
+checksum = "928d8039a66cce5efcfd35e88b32d3defc8eba630b3ac451522997f563956a52"
 dependencies = [
  "derive_more",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "n0-future",
 ]
 
@@ -3291,10 +3378,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "netdev"
-version = "0.40.1"
+name = "ndk-context"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0a0096d9613ee878dba89bbe595f079d373e3f1960d882e4f2f78ff9c30a0a"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "netdev"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
 dependencies = [
  "block2",
  "dispatch2",
@@ -3303,13 +3396,15 @@ dependencies = [
  "libc",
  "mac-addr",
  "netlink-packet-core",
- "netlink-packet-route",
+ "netlink-packet-route 0.29.0",
  "netlink-sys",
  "objc2-core-foundation",
+ "objc2-core-wlan",
+ "objc2-foundation",
  "objc2-system-configuration",
  "once_cell",
  "plist",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3326,6 +3421,18 @@ name = "netlink-packet-route"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
+dependencies = [
+ "bitflags",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
 dependencies = [
  "bitflags",
  "libc",
@@ -3362,9 +3469,9 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.15.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1b27babe89ef9f2237bc6c028bea24fa84163a1b6f8f17ff93573ebd7d861f"
+checksum = "2071e0c2b5b229622c459096b84f1ad51afa150cdeeefdad491ef3704e581d91"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3372,12 +3479,12 @@ dependencies = [
  "derive_more",
  "js-sys",
  "libc",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
  "n0-future",
  "n0-watcher",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route",
+ "netlink-packet-route 0.30.0",
  "netlink-proto",
  "netlink-sys",
  "noq-udp",
@@ -3414,12 +3521,13 @@ dependencies = [
 
 [[package]]
 name = "noq"
-version = "0.17.0"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df966fb44ac763bc86da97fa6c811c54ae82ef656575949f93c6dae0c9f09bf"
+checksum = "198b99fc085a5db1f7d259edb5ede8311e59f28cdd2687920b4313613d21a73f"
 dependencies = [
  "bytes",
  "cfg_aliases",
+ "derive_more",
  "noq-proto",
  "noq-udp",
  "pin-project-lite",
@@ -3435,19 +3543,19 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "0.16.0"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c61b72abd670eebc05b5cf720e077b04a3ef3354bc7bc19f1c3524cb424db7b"
+checksum = "1ab0ac774795ce1e42a7e61266e71f3be8110210630441169ac8dda403dd23f1"
 dependencies = [
  "aes-gcm",
  "bytes",
  "derive_more",
  "enum-assoc",
- "fastbloom",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "identity-hash",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3462,9 +3570,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "0.9.0"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9be4fedd6b98f3ba82ccd3506f4d0219fb723c3f97c67e12fe1494aa020e44"
+checksum = "b3c1520eacd33fd6b009e2e70116b05508ade51db5e0d315ff8bf6b702148c2b"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -3478,21 +3586,6 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
-name = "ntimestamp"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50f94c405726d3e0095e89e72f75ce7f6587b94a8bd8dc8054b73f65c0fd68c"
-dependencies = [
- "base32",
- "document-features",
- "getrandom 0.2.17",
- "httpdate",
- "js-sys",
- "once_cell",
- "serde",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -3646,10 +3739,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-wlan"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
+ "objc2-security-foundation",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "objc2-security"
@@ -3660,6 +3780,16 @@ dependencies = [
  "bitflags",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -3948,25 +4078,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkarr"
-version = "5.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bfb9143bbba379f246211eb68074d78db9cc048e4c5701f3b0e6cb1ec67ca2"
-dependencies = [
- "base32",
- "bytes",
- "cfg_aliases",
- "document-features",
- "ed25519-dalek",
- "getrandom 0.4.2",
- "ntimestamp",
- "self_cell",
- "serde",
- "simple-dns",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3989,9 +4100,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.11"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der 0.8.0",
  "spki 0.8.0",
@@ -4060,23 +4171,22 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.15.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74748bc706fa6b6aebac6bbe0bbe0de806b384cb5c557ea974f771360a4e3858"
+checksum = "64959cbabf952c8ffcbaea13745308508f1f825922f4068353f3de08d42cf214"
 dependencies = [
  "base64",
  "bytes",
  "derive_more",
- "futures-lite",
- "futures-util",
  "hyper-util",
  "igd-next",
  "iroh-metrics",
  "libc",
- "n0-error",
+ "n0-error 1.0.0-rc.0",
+ "n0-future",
  "netwatch",
  "num_enum",
- "rand 0.9.4",
+ "rand 0.10.1",
  "serde",
  "smallvec",
  "socket2",
@@ -4097,7 +4207,6 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
- "heapless",
  "postcard-derive",
  "serde",
 ]
@@ -4165,6 +4274,17 @@ checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -4470,6 +4590,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4505,6 +4636,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4597,7 +4743,6 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -4617,6 +4762,42 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4626,7 +4807,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -4760,9 +4940,9 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -4772,7 +4952,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4865,7 +5045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4890,12 +5070,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "self_cell"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -5077,6 +5251,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5089,13 +5279,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.11.0-rc.10",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5135,15 +5325,25 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.10"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -5231,9 +5431,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spin"
@@ -5362,6 +5559,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5657,20 +5875,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-websockets"
-version = "0.12.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b6348ebfaaecd771cecb69e832961d277f59845d4220a584701f72728152b7"
+checksum = "dad543404f98bfc969aeb71994105c592acfc6c43323fddcd016bb208d1c65cb"
 dependencies = [
  "base64",
  "bytes",
  "futures-core",
  "futures-sink",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "http",
  "httparse",
- "rand 0.9.4",
+ "rand 0.10.1",
  "ring",
  "rustls-pki-types",
+ "sha1_smol",
  "simdutf8",
  "tokio",
  "tokio-rustls",
@@ -6219,32 +6438,21 @@ dependencies = [
  "anyhow",
  "derive_builder",
  "rustversion",
- "vergen-lib 9.1.0",
+ "vergen-lib",
 ]
 
 [[package]]
 name = "vergen-gitcl"
-version = "1.0.8"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9dfc1de6eb2e08a4ddf152f1b179529638bedc0ea95e6d667c014506377aefe"
+checksum = "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9"
 dependencies = [
  "anyhow",
  "derive_builder",
  "rustversion",
  "time",
  "vergen",
- "vergen-lib 0.1.6",
-]
-
-[[package]]
-name = "vergen-lib"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
+ "vergen-lib",
 ]
 
 [[package]]
@@ -6416,9 +6624,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -6640,15 +6848,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -7055,12 +7254,6 @@ dependencies = [
  "syn",
  "synstructure",
 ]
-
-[[package]]
-name = "z32"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 
 [[package]]
 name = "zerocopy"

--- a/bauplan-longbow/Cargo.toml
+++ b/bauplan-longbow/Cargo.toml
@@ -18,8 +18,9 @@ arrow = "58"
 arrow-ipc = { version = "58", features = ["zstd"] }
 bytes = "1"
 futures.workspace = true
-iroh = "0.97"
+iroh = "1.0.0-rc.1"
 n0-error = "0.1"
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
@@ -27,7 +28,6 @@ url.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true
-rand = "0.9"
 test-log = { version = "0.2", features = ["trace"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/bauplan-longbow/src/client.rs
+++ b/bauplan-longbow/src/client.rs
@@ -2,7 +2,7 @@ use arrow::{array::RecordBatch, buffer::Buffer, datatypes::SchemaRef, ipc::reade
 use futures::stream::{self, Stream};
 use iroh::{
     Endpoint, EndpointAddr,
-    endpoint::{ConnectError, Connection, RecvStream, presets::Preset},
+    endpoint::{ConnectError, Connection, RecvStream},
 };
 use n0_error::StdResultExt;
 use tracing::debug;
@@ -10,19 +10,16 @@ use tracing::debug;
 use crate::{ALPN, Error, StreamToken};
 
 struct ArrowStreamState {
-    conn: Connection,
     recv: RecvStream,
     decoder: StreamDecoder,
     remaining: Buffer,
     batch: Option<RecordBatch>,
-    _endpoint: Endpoint,
+
+    conn: Connection,
 }
 
 impl Drop for ArrowStreamState {
     fn drop(&mut self) {
-        // Iroh says to use Endpoint::close, which waits for the
-        // CONNECTION_CLOSE to reach the server. But we don't care, because
-        // we're the only ones receiving data, and the extra latency is stupid.
         self.conn.close(0_u8.into(), b"done");
     }
 }
@@ -33,14 +30,12 @@ impl Drop for ArrowStreamState {
 /// If this optimization was successful, the opened stream is returned along
 /// with the connection. Otherwise, it should be opened manually.
 async fn connect(
-    preset: impl Preset,
+    endpoint: &Endpoint,
     server: EndpointAddr,
     initial_token: StreamToken,
-) -> Result<(Connection, Endpoint, Option<RecvStream>), Error> {
+) -> Result<(Connection, Option<RecvStream>), Error> {
     // TODO: we should maybe disable ipv6 proactively, since our servers don't
     // support it and it can cause extra startup latency. :(
-    let endpoint = Endpoint::builder(preset).bind().await?;
-
     let connecting = endpoint
         .connect_with_opts(server, ALPN, Default::default())
         .await
@@ -76,23 +71,23 @@ async fn connect(
         }
     };
 
-    Ok((conn, endpoint, recv))
+    Ok((conn, recv))
 }
 
 /// Connect to an endpoint with the intention to download query results.
 ///
 /// Returns the stream schema and a stream of record batches.
 pub async fn fetch_query_results(
-    preset: impl Preset,
+    endpoint: &Endpoint,
     server: EndpointAddr,
 ) -> Result<
     (
         SchemaRef,
-        impl Stream<Item = Result<RecordBatch, Error>> + Unpin,
+        impl Stream<Item = Result<RecordBatch, Error>> + Unpin + use<>,
     ),
     Error,
 > {
-    let (conn, endpoint, recv) = connect(preset, server, StreamToken::QueryResults).await?;
+    let (conn, recv) = connect(endpoint, server, StreamToken::QueryResults).await?;
 
     let mut recv = match recv {
         Some(r) => r,
@@ -112,7 +107,7 @@ pub async fn fetch_query_results(
     let schema = loop {
         match recv.read_chunk(usize::MAX).await? {
             Some(chunk) => {
-                remaining = Buffer::from(chunk.bytes);
+                remaining = Buffer::from(chunk);
                 if let Some(batch) = decoder.decode(&mut remaining)? {
                     first_batch = Some(batch);
                     break decoder.schema().unwrap();
@@ -130,12 +125,12 @@ pub async fn fetch_query_results(
     };
 
     let state = ArrowStreamState {
-        conn,
         recv,
         decoder,
         remaining,
         batch: first_batch,
-        _endpoint: endpoint,
+
+        conn,
     };
 
     let stream = Box::pin(stream::try_unfold(state, |mut state| async move {
@@ -150,7 +145,7 @@ pub async fn fetch_query_results(
 
             match state.recv.read_chunk(usize::MAX).await? {
                 Some(chunk) => {
-                    state.remaining = Buffer::from(chunk.bytes);
+                    state.remaining = Buffer::from(chunk);
                     if let Some(batch) = state.decoder.decode(&mut state.remaining)? {
                         return Ok(Some((batch, state)));
                     }

--- a/bauplan-longbow/src/lib.rs
+++ b/bauplan-longbow/src/lib.rs
@@ -114,6 +114,7 @@ impl iroh::endpoint::presets::Preset for BauplanPreset {
             .clear_address_lookup()
             .alpns(vec![ALPN.to_owned()])
             .relay_mode(RelayMode::Custom(self.relay_map()))
+            .crypto_provider(std::sync::Arc::new(rustls::crypto::ring::default_provider()))
     }
 }
 
@@ -202,7 +203,7 @@ mod tests {
     async fn query_results() -> anyhow::Result<()> {
         use iroh::EndpointAddr;
 
-        let secret_key = iroh::SecretKey::generate(&mut rand::rng());
+        let secret_key = iroh::SecretKey::generate();
         let public_key = secret_key.public();
 
         let batches = test_batches();
@@ -210,22 +211,28 @@ mod tests {
         let server_task = tokio::spawn({
             let batches = batches.clone();
             async move {
-                let mut server =
-                    ArrowIPCServer::accept(BauplanPreset::default(), secret_key, schema).await?;
+                let endpoint = iroh::Endpoint::builder(BauplanPreset::default())
+                    .secret_key(secret_key)
+                    .bind()
+                    .await?;
+
+                let mut server = ArrowIPCServer::accept(&endpoint, schema).await?;
 
                 for batch in batches {
                     server.send_record_batch(&batch).await?;
                 }
 
                 server.finish().await?;
+                endpoint.close().await;
                 Ok::<_, anyhow::Error>(())
             }
         });
 
         let preset = BauplanPreset::default();
         let server_addr = preset.add_relay_urls(EndpointAddr::new(public_key));
+        let endpoint = iroh::Endpoint::bind(preset).await?;
 
-        let (_schema, mut stream) = fetch_query_results(preset, server_addr)
+        let (_schema, mut stream) = fetch_query_results(&endpoint, server_addr)
             .await
             .context("fetch_query_results failed")?;
 
@@ -233,6 +240,8 @@ mod tests {
         while let Some(batch) = stream.next().await {
             received.push(batch.context("batch")?);
         }
+
+        endpoint.close().await;
 
         assert_eq!(received.len(), batches.len());
         for (got, expected) in received.iter().zip(&batches) {

--- a/bauplan-longbow/src/server.rs
+++ b/bauplan-longbow/src/server.rs
@@ -8,8 +8,8 @@ use arrow::{
 };
 use bytes::{BufMut, BytesMut};
 use iroh::{
-    Endpoint, SecretKey,
-    endpoint::{Connection, ConnectionState, IncomingZeroRtt, SendStream, presets::Preset},
+    Endpoint,
+    endpoint::{Connection, ConnectionState, IncomingZeroRtt, SendStream},
 };
 use tracing::{debug, error};
 
@@ -17,15 +17,7 @@ use crate::{Error, StreamToken};
 
 /// Binds an endpoint and waits for the first connection, then returns it. This
 /// will run forever and has no inherent timeout.
-async fn accept_connection(
-    preset: impl Preset,
-    secret_key: SecretKey,
-) -> Result<(Endpoint, Connection<IncomingZeroRtt>), Error> {
-    let endpoint = Endpoint::builder(preset)
-        .secret_key(secret_key)
-        .bind()
-        .await?;
-
+pub async fn accept_connection(endpoint: &Endpoint) -> Result<Connection<IncomingZeroRtt>, Error> {
     loop {
         let Some(incoming) = endpoint.accept().await else {
             // The endpoint was dropped.
@@ -33,7 +25,7 @@ async fn accept_connection(
         };
 
         match incoming.accept() {
-            Ok(acc) => return Ok((endpoint, acc.into_0rtt())),
+            Ok(acc) => return Ok(acc.into_0rtt()),
             Err(err) => {
                 error!(?err, "handshake failed, listening again");
                 continue;
@@ -44,7 +36,7 @@ async fn accept_connection(
 
 /// Accept the next bidirectional stream on a connection, reading the
 /// one-byte [`StreamToken`] the client sends to identify the stream type.
-async fn accept_stream<C: ConnectionState>(
+pub async fn accept_stream<C: ConnectionState>(
     conn: &Connection<C>,
 ) -> Result<(StreamToken, SendStream), Error> {
     let (send, mut recv) = conn.accept_bi().await?;
@@ -63,27 +55,20 @@ async fn accept_stream<C: ConnectionState>(
 
 /// A server capable of pushing arrow record batches to a single client.
 pub struct ArrowIPCServer {
-    endpoint: Endpoint,
     send: SendStream,
     writer: StreamWriter<bytes::buf::Writer<BytesMut>>,
 }
 
 impl std::fmt::Debug for ArrowIPCServer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ArrowIPCServer")
-            .field("endpoint", &self.endpoint)
-            .finish()
+        f.debug_struct("ArrowIPCServer").finish()
     }
 }
 
 impl ArrowIPCServer {
     /// Sets up a server and waits for the client. This has no internal timeout.
-    pub async fn accept(
-        preset: impl Preset,
-        secret_key: SecretKey,
-        schema: SchemaRef,
-    ) -> Result<Self, Error> {
-        let (endpoint, conn) = accept_connection(preset, secret_key).await?;
+    pub async fn accept(endpoint: &Endpoint, schema: SchemaRef) -> Result<Self, Error> {
+        let conn = accept_connection(endpoint).await?;
         let (token, send) = accept_stream(&conn).await?;
         if token != StreamToken::QueryResults {
             return Err(Error::InvalidStreamToken);
@@ -96,11 +81,7 @@ impl ArrowIPCServer {
         let buf = BytesMut::new().writer();
         let writer = StreamWriter::try_new_with_options(buf, &schema, write_options)?;
 
-        Ok(Self {
-            endpoint,
-            send,
-            writer,
-        })
+        Ok(Self { send, writer })
     }
 
     /// Sends a record batch over the wire.
@@ -126,8 +107,6 @@ impl ArrowIPCServer {
         // Signal that no more data will be sent.
         let _ = self.send.finish();
         self.send.stopped().await.map_err(|_| Error::StreamClosed)?;
-
-        self.endpoint.close().await;
         Ok(())
     }
 }

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -15,7 +15,7 @@ use arrow::{
 use arrow_flight::error::{FlightError, Result as FlightResult};
 use bauplan::flight::{fetch_flight_results, limit_rows};
 use bauplan::grpc::{self, generated as commanderpb};
-use bauplan_longbow::BauplanPreset;
+use bauplan_longbow::{BauplanPreset, iroh};
 use commanderpb::runner_event::Event as RunnerEvent;
 use futures::{Stream, StreamExt, TryStreamExt, future::Either};
 use tabwriter::TabWriter;
@@ -152,51 +152,39 @@ pub(crate) async fn handle(cli: &Cli, args: QueryArgs) -> anyhow::Result<()> {
 
     progress.set_message("Fetching results...");
 
-    let tp = cli.traceparent();
-    let longbow_key = if resp.longbow_public_key.is_empty() {
-        None
+    let (longbow_endpoint, schema, batches) = if !resp.longbow_public_key.is_empty() {
+        let (endpoint, schema, batches) =
+            fetch_results_longbow(resp.longbow_public_key.as_slice(), timeout).await?;
+        (Some(endpoint), schema, Either::Left(batches))
     } else {
-        Some(resp.longbow_public_key)
+        let tp = cli.traceparent();
+        let (schema, batches) = fetch_results(flight_event, timeout, row_limit, tp).await?;
+
+        (None, schema, Either::Right(batches))
     };
 
-    let (schema, batches) =
-        fetch_results(longbow_key, flight_event, timeout, row_limit, tp).await?;
-
+    let batches = limit_rows(batches, row_limit);
     futures::pin_mut!(batches);
 
     progress.finish_with_done();
     match cli.global.output {
-        Output::Tty => print_tty(schema, batches, !no_trunc).await,
-        Output::Json => print_json(batches, &job_id).await,
+        Output::Tty => print_tty(schema, batches, !no_trunc).await?,
+        Output::Json => print_json(batches, &job_id).await?,
     }
+
+    if let Some(endpoint) = longbow_endpoint {
+        endpoint.close().await;
+    }
+
+    Ok(())
 }
 
 async fn fetch_results(
-    longbow_public_key: Option<Vec<u8>>,
     flight_event: Option<commanderpb::FlightServerStartEvent>,
     timeout: time::Duration,
     row_limit: Option<u64>,
     traceparent: String,
 ) -> anyhow::Result<(Schema, impl Stream<Item = FlightResult<RecordBatch>>)> {
-    if let Some(public_key_bytes) = longbow_public_key {
-        let public_key = bauplan_longbow::iroh::PublicKey::try_from(public_key_bytes.as_slice())
-            .context("invalid longbow public key")?;
-        let preset = BauplanPreset::default();
-        let addr = bauplan_longbow::iroh::EndpointAddr::new(public_key);
-        let addr = preset.add_relay_urls(addr);
-
-        let (schema, stream) =
-            tokio::time::timeout(timeout, bauplan_longbow::fetch_query_results(preset, addr))
-                .await
-                .context("failed to fetch query results")??;
-
-        let schema: Schema = schema.as_ref().clone();
-        let stream = stream
-            .map(|r| r.map_err(|e| FlightError::Arrow(ArrowError::ExternalError(Box::new(e)))));
-        let stream = limit_rows(stream, row_limit);
-        return Ok((schema, Either::Left(stream)));
-    }
-
     let Some(commanderpb::FlightServerStartEvent {
         endpoint,
         magic_token,
@@ -226,7 +214,36 @@ async fn fetch_results(
     .await
     .context("Failed to fetch query results")?;
 
-    Ok((schema, Either::Right(batches)))
+    Ok((schema, batches))
+}
+
+async fn fetch_results_longbow(
+    public_key: &[u8],
+    timeout: time::Duration,
+) -> anyhow::Result<(
+    iroh::Endpoint,
+    Schema,
+    impl Stream<Item = FlightResult<RecordBatch>>,
+)> {
+    let public_key = bauplan_longbow::iroh::PublicKey::try_from(public_key)
+        .context("invalid longbow public key")?;
+    let preset = BauplanPreset::default();
+    let addr = bauplan_longbow::iroh::EndpointAddr::new(public_key);
+    let addr = preset.add_relay_urls(addr);
+
+    let endpoint = iroh::Endpoint::bind(preset.clone()).await?;
+    let (schema, stream) = tokio::time::timeout(
+        timeout,
+        bauplan_longbow::fetch_query_results(&endpoint, addr),
+    )
+    .await
+    .context("failed to fetch query results")??;
+
+    let schema: Schema = schema.as_ref().clone();
+    let stream =
+        stream.map(|r| r.map_err(|e| FlightError::Arrow(ArrowError::ExternalError(Box::new(e)))));
+
+    Ok((endpoint, schema, stream))
 }
 
 async fn print_tty(

--- a/src/flight.rs
+++ b/src/flight.rs
@@ -1,6 +1,6 @@
 //! Support for fetching query results via Arrow Flight.
 
-use std::{pin::Pin, time};
+use std::time;
 
 use arrow::{array::RecordBatch, datatypes::Schema};
 use arrow_flight::{
@@ -34,8 +34,6 @@ pub async fn fetch_flight_results(
     let criteria = json!({"max_rows": row_limit}).to_string();
     let (schema, batches) =
         fetch(channel.clone(), auth_token.clone(), criteria, traceparent).await?;
-
-    let batches = limit_rows(batches, row_limit);
 
     // After all batches are consumed, tell the flight server to shut down.
     //

--- a/src/python.rs
+++ b/src/python.rs
@@ -159,6 +159,12 @@ pub(crate) struct Client {
     pub(crate) agent: ureq::Agent,
     pub(crate) grpc: grpc::Client,
     pub(crate) client_timeout: time::Duration,
+    /// NB: we don't ever call `endpoint.close()`, because there's no good time
+    /// to do that. It's probably fine; in normal use all connections will have
+    /// finished out long before we drop the client. If any are still open when
+    /// we drop, then the server will have to wait for the idle timeout, but
+    /// that's not that tragic.
+    pub(crate) longbow_endpoint: tokio::sync::OnceCell<bauplan_longbow::iroh::Endpoint>,
 }
 
 #[pymethods]
@@ -224,6 +230,7 @@ impl Client {
             agent,
             grpc,
             client_timeout,
+            longbow_endpoint: tokio::sync::OnceCell::new(),
         })
     }
 }

--- a/src/python/query.rs
+++ b/src/python/query.rs
@@ -14,7 +14,7 @@ use polyglot_sql::{Expression, Parser, builder, expressions::TableRef};
 use pyo3::{IntoPyObjectExt, exceptions::PyValueError, prelude::*};
 use tracing::{debug, error, info};
 
-use bauplan_longbow::BauplanPreset;
+use bauplan_longbow::{BauplanPreset, iroh};
 
 use crate::{
     flight,
@@ -114,15 +114,23 @@ impl Client {
         }
 
         if !longbow_public_key.is_empty() {
-            let public_key =
-                bauplan_longbow::iroh::PublicKey::try_from(longbow_public_key.as_slice())
-                    .map_err(|_| query_err("invalid longbow public key"))?;
+            let public_key = iroh::PublicKey::try_from(longbow_public_key.as_slice())
+                .map_err(|_| query_err("invalid longbow public key"))?;
             let preset = BauplanPreset::default();
-            let addr = bauplan_longbow::iroh::EndpointAddr::new(public_key);
+            let addr = iroh::EndpointAddr::new(public_key);
             let addr = preset.add_relay_urls(addr);
 
-            let (schema, stream) = tokio::time::timeout(timeout, async {
-                bauplan_longbow::fetch_query_results(preset, addr)
+            let endpoint = self
+                .longbow_endpoint
+                .get_or_try_init(|| async {
+                    iroh::Endpoint::bind(BauplanPreset::default())
+                        .await
+                        .map_err(|_| query_err("failed to bind longbow endpoint"))
+                })
+                .await?;
+
+            let (schema, batches) = tokio::time::timeout(timeout, async {
+                bauplan_longbow::fetch_query_results(endpoint, addr)
                     .await
                     .map_err(query_err)
             })
@@ -130,8 +138,8 @@ impl Client {
             .map_err(|_| query_err("timed out fetching query results"))??;
 
             let schema: Schema = schema.as_ref().clone();
-            let stream = flight::limit_rows(stream, max_rows);
-            return Ok((schema, Either::Left(stream.map_err(query_err))));
+            let batches = flight::limit_rows(batches.map_err(query_err), max_rows);
+            return Ok((schema, Either::Left(batches)));
         }
 
         let Some(commanderpb::FlightServerStartEvent {
@@ -160,7 +168,8 @@ impl Client {
                 .await
                 .map_err(|_| query_err("failed to fetch query results"))?;
 
-        Ok((schema, Either::Right(batches.map_err(query_err))))
+        let batches = flight::limit_rows(batches.map_err(query_err), max_rows);
+        Ok((schema, Either::Right(batches)))
     }
 
     #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
We also update the interfaces to take a borrow endpoint, so we can reuse it in the pysdk.

In particular, this pulls in
https://github.com/n0-computer/iroh/pull/4270, which makes `endpoint.close()` significantly faster, so we can now gracefully shutdown.