### PR TITLE
build: group dependabot updates to examples

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -22,3 +22,19 @@ updates:
       prefix: "chore(pysdk)"
     cooldown:
       default-days: 7
+  - package-ecosystem: uv
+    directories:
+      - /examples/**/*
+    schedule:
+      interval: daily
+      time: "09:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: "chore(examples)"
+    cooldown:
+      default-days: 7
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This prevents one PR per uv.lock, which we've had a few times recently.