### PR TITLE
feat(pysdk): expose job error messages

### DIFF
--- a/python/bauplan/schema.pyi
+++ b/python/bauplan/schema.pyi
@@ -146,6 +146,11 @@ class Job:
         When the job was created.
         """
     @property
+    def error_message(self, /) -> str | None:
+        """
+        Error message for failed jobs, when available.
+        """
+    @property
     def finished_at(self, /) -> datetime | None:
         """
         When the job finished (successfully or not).
@@ -195,6 +200,8 @@ class JobContext:
     def dag_edges(self, /) -> list[DAGEdge]: ...
     @property
     def dag_nodes(self, /) -> list[DAGNode]: ...
+    @property
+    def error_message(self, /) -> str | None: ...
     @property
     def id(self, /) -> str: ...
     @property

--- a/src/cli/job.rs
+++ b/src/cli/job.rs
@@ -394,6 +394,9 @@ async fn handle_get(cli: &Cli, args: JobGetArgs) -> anyhow::Result<()> {
             writeln!(&mut tw, "Kind:\t{}", job.kind)?;
             writeln!(&mut tw, "User:\t{}", job.user)?;
             writeln!(&mut tw, "Runner:\t{}", job.runner)?;
+            if let Some(error_message) = &job.error_message {
+                writeln!(&mut tw, "Error:\t{}", error_message)?;
+            }
             writeln!(
                 &mut tw,
                 "Created:\t{}",

--- a/src/grpc/job.rs
+++ b/src/grpc/job.rs
@@ -205,6 +205,8 @@ pub struct Job {
     pub finished_at: Option<DateTime<Utc>>,
     /// The runner instance assigned to execute this job.
     pub runner: String,
+    /// Error message for failed jobs, when available.
+    pub error_message: Option<String>,
 }
 
 #[cfg(feature = "python")]
@@ -234,6 +236,7 @@ impl From<commanderpb::JobInfo> for Job {
             started_at: info.started_at.and_then(pb_to_chrono),
             finished_at: info.finished_at.and_then(pb_to_chrono),
             runner: info.runner,
+            error_message: info.error_message,
         }
     }
 }

--- a/src/proto/bpln_proto/commander/service/v2/common.proto
+++ b/src/proto/bpln_proto/commander/service/v2/common.proto
@@ -75,6 +75,7 @@ message JobInfo {
   string runner = 9;
   JobStateType status = 10;
   JobKind kind_type = 11;
+  optional string error_message = 13;
 }
 
 // LEGACY: DO NOT ADD NEW FIELDS HERE. REFACTOR NEEDED

--- a/src/proto/bpln_proto/commander/service/v2/job_context.proto
+++ b/src/proto/bpln_proto/commander/service/v2/job_context.proto
@@ -63,6 +63,9 @@ message JobContext {
 
   // Logs for Job
   repeated RunnerEvent job_events = 7;
+
+  // Error message for failed jobs, when available.
+  optional string error_message = 11;
 }
 
 message JobError {

--- a/src/python/job.rs
+++ b/src/python/job.rs
@@ -314,6 +314,7 @@ pub(crate) struct JobContext {
     pub dag_nodes: Vec<DAGNode>,
     pub dag_edges: Vec<DAGEdge>,
     pub snapshot_dict: HashMap<String, String>,
+    pub error_message: Option<String>,
 }
 
 impl TryFrom<commanderpb::JobContext> for JobContext {
@@ -356,6 +357,7 @@ impl TryFrom<commanderpb::JobContext> for JobContext {
             dag_nodes,
             dag_edges,
             snapshot_dict,
+            error_message: ctx.error_message,
         })
     }
 }


### PR DESCRIPTION
Surface failed job messages on Job and JobContext so clients can diagnose failures directly. 
Show the message in job get output when one is available.