### PR TITLE
fix: respect explicit job user filters

### DIFF
--- a/src/cli/job.rs
+++ b/src/cli/job.rs
@@ -251,9 +251,10 @@ async fn handle_ls(cli: &Cli, args: JobLsArgs) -> anyhow::Result<()> {
         .transpose()?
         .map(to_proto_timestamp);
 
+    let all_users = args.all_users || !args.user.is_empty();
     let base_request = commanderpb::GetJobsRequest {
         job_ids: args.id,
-        all_users: args.all_users,
+        all_users,
         filter_users: args.user,
         filter_kinds,
         filter_statuses,

--- a/src/python/job.rs
+++ b/src/python/job.rs
@@ -475,6 +475,7 @@ impl Client {
 
         let job_ids = filter_by_ids.unwrap_or_default().0;
         let filter_users = filter_by_users.unwrap_or_default().0;
+        let all_users = all_users || !filter_users.is_empty();
         let filter_kinds: Vec<i32> = filter_by_kinds.unwrap_or_default().into();
         let filter_statuses: Vec<i32> = filter_by_statuses.unwrap_or_default().into();
 


### PR DESCRIPTION
When users are provided, send the request as an explicit user-scoped listing instead of also applying the default current-user scope.
This keeps CLI and PySDK job listing behavior aligned with the selected filters.