### PR TITLE
fix(cli): accept api_endpoint in config set

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -23,6 +23,8 @@ pub(crate) enum ConfigCommand {
 #[clap(rename_all = "snake_case")]
 pub(crate) enum ConfigSetting {
     ApiKey,
+    #[value(hide = true)]
+    ApiEndpoint,
     ActiveBranch,
 }
 
@@ -30,6 +32,7 @@ impl std::fmt::Display for ConfigSetting {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ConfigSetting::ApiKey => f.write_str("api_key"),
+            ConfigSetting::ApiEndpoint => f.write_str("api_endpoint"),
             ConfigSetting::ActiveBranch => f.write_str("active_branch"),
         }
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -9,6 +9,7 @@ use std::fmt::Write as _;
 mod cli {
     mod auth;
     mod branch;
+    mod config;
     mod import;
     mod init;
     mod job;

--- a/tests/cli/config.rs
+++ b/tests/cli/config.rs
@@ -1,0 +1,35 @@
+use anyhow::Result;
+
+#[test]
+fn config_set_writes_supported_profile_settings() -> Result<()> {
+    let home = tempfile::tempdir()?;
+    let api_key = "bpln_test_key";
+    let api_endpoint = "https://api.use1.adev.bauplanlabs.com";
+    let active_branch = "feature";
+
+    config_set(&home, "active_branch", active_branch);
+    config_set(&home, "api_endpoint", api_endpoint);
+    config_set(&home, "api_key", api_key);
+
+    let config = std::fs::read_to_string(home.path().join(".bauplan/config.yaml"))?;
+    let parsed: serde_yaml::Value = serde_yaml::from_str(&config)?;
+    let profile = &parsed["profiles"]["default"];
+
+    assert_eq!(profile["api_key"].as_str(), Some(api_key));
+    assert_eq!(profile["api_endpoint"].as_str(), Some(api_endpoint));
+    assert_eq!(profile["active_branch"].as_str(), Some("main"));
+
+    Ok(())
+}
+
+fn config_set(home: &tempfile::TempDir, name: &str, value: &str) {
+    crate::bauplan()
+        .env("HOME", home.path())
+        .env("USERPROFILE", home.path())
+        .env_remove("BAUPLAN_PROFILE")
+        .env_remove("BAUPLAN_API_KEY")
+        .env_remove("BAUPLAN_API_ENDPOINT")
+        .args(["config", "set", name, value])
+        .assert()
+        .success();
+}


### PR DESCRIPTION
api_endpoint is already resolved from profile config, but clap rejected it as an unsupported setting.