### PR TITLE
fix(cli): add `version` to generated pyproject in init

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -73,12 +73,22 @@ pub(crate) fn handle(args: InitArgs) -> anyhow::Result<()> {
     //
     // [project]
     // name = "my_project"
-    // requires-python = ">=3.12"
+    // version = "0.1.0"
+    // requires-python = "~=3.12"
     // dependencies = ["bauplan=~x.x.x"]
+    //
+    // [dependency-groups]
+    // dev = [
+    //     "ruff>=0.15",
+    //     "ty>=0.0.48",
+    //     "polars>=1"
+    // ]
     let bauplan_version = concat!("bauplan~=", env!("CARGO_PKG_VERSION")).into();
 
+    let mut pyproject = toml::Table::default();
     let mut project = toml::Table::default();
     project.insert("name".into(), toml::Value::String(project_name.clone()));
+    project.insert("version".into(), toml::Value::String("0.1.0".into()));
     project.insert(
         "requires-python".into(),
         toml::Value::String("~=3.12".into()),
@@ -88,8 +98,21 @@ pub(crate) fn handle(args: InitArgs) -> anyhow::Result<()> {
         toml::Value::Array(vec![toml::Value::String(bauplan_version)]),
     );
 
-    let mut pyproject = toml::Table::default();
+    let mut dependency_groups = toml::Table::default();
+    dependency_groups.insert(
+        "dev".into(),
+        toml::Value::Array(vec![
+            toml::Value::String("ruff>=0.15".into()),
+            toml::Value::String("ty>=0.0.48".into()),
+            toml::Value::String("polars>=1".into()),
+        ]),
+    );
+
     pyproject.insert("project".into(), toml::Value::Table(project));
+    pyproject.insert(
+        "dependency-groups".into(),
+        toml::Value::Table(dependency_groups),
+    );
 
     let pyproject_toml =
         toml::to_string_pretty(&pyproject).context("failed to serialize pyproject.toml")?;

--- a/src/cli/init/models.py
+++ b/src/cli/init/models.py
@@ -20,9 +20,9 @@ def survival_rate_by_age(
     | 19       | 0.3           |
     | 20       | 0.4           |
     """
-    import polars as pl # noqa
+    import polars as pl
 
-    df = pl.from_arrow(passengers)
+    df = pl.DataFrame(passengers)
     return (
         df.group_by(pl.col("Age").floor())
         .agg(pl.col("Survived").mean().alias("survival_rate"))

--- a/tests/cli/init.rs
+++ b/tests/cli/init.rs
@@ -13,15 +13,28 @@ fn init_generates_valid_dag() -> Result<()> {
         .assert()
         .success();
 
-    let models = dir.path().join("models.py");
-
-    let output = Command::new("uvx")
-        .args(["--isolated", "ruff", "check", "--isolated"])
-        .arg(&models)
+    let output = Command::new("uv")
+        .arg("--directory")
+        .arg(dir.path())
+        .args(["run", "ruff", "check"])
         .output()?;
     if !output.status.success() {
         bail!(
             "ruff check failed:\n{}",
+            [&output.stdout[..], &output.stderr[..]]
+                .concat()
+                .to_str_lossy()
+        );
+    }
+
+    let output = Command::new("uv")
+        .arg("--directory")
+        .arg(dir.path())
+        .args(["run", "ty", "check"])
+        .output()?;
+    if !output.status.success() {
+        bail!(
+            "ty check failed:\n{}",
             [&output.stdout[..], &output.stderr[..]]
                 .concat()
                 .to_str_lossy()


### PR DESCRIPTION
This fixes `uv` invocations, which otherwise fail with:

```
error: Failed to parse: `pyproject.toml`
  Caused by: TOML parse error at line 1, column 1
  |
1 | [project]
  | ^^^^^^^^^
`pyproject.toml` is using the `[project]` table, but the required `project.version` field is neither s
```


We also add `ruff` and `ty` as dev dependencies, and `polars`, so that `models.py` passes typechecking. Finally, there's a typechecking error, because `pl.from_arrow` returns `DataFrame | Series`.