### PR TITLE
fix(cli): handle ambiguous job prefix lookups

### DIFF
--- a/src/cli/job.rs
+++ b/src/cli/job.rs
@@ -370,6 +370,7 @@ async fn handle_get(cli: &Cli, args: JobGetArgs) -> anyhow::Result<()> {
     let mut request = cli.traced(commanderpb::GetJobsRequest {
         job_ids: vec![args.job_id.clone()],
         all_users: true,
+        max_records: 2,
         ..Default::default()
     });
     request.set_timeout(timeout);
@@ -379,7 +380,11 @@ async fn handle_get(cli: &Cli, args: JobGetArgs) -> anyhow::Result<()> {
         .await
         .map_err(format_grpc_status)?
         .into_inner();
-    let Some(job) = response.jobs.into_iter().next().map(Job::from) else {
+    let jobs = response.jobs;
+    if jobs.len() > 1 {
+        bail!("multiple jobs match prefix, please be more specific");
+    }
+    let Some(job) = jobs.into_iter().next().map(Job::from) else {
         bail!("job not found: {}", args.job_id);
     };
 

--- a/src/python/job.rs
+++ b/src/python/job.rs
@@ -403,6 +403,7 @@ impl Client {
         let mut req = Request::new(commanderpb::GetJobsRequest {
             job_ids: vec![job_id.to_string()],
             all_users: true,
+            max_records: 2,
             ..Default::default()
         });
         req.set_timeout(self.client_timeout);
@@ -413,6 +414,11 @@ impl Client {
         let jobs = response.into_inner().jobs;
         if jobs.is_empty() {
             return Err(BauplanError::new_err(format!("job not found: {}", job_id)));
+        }
+        if jobs.len() > 1 {
+            return Err(BauplanError::new_err(
+                "multiple jobs match prefix, please be more specific",
+            ));
         }
 
         Ok(jobs.into_iter().next().unwrap().into())


### PR DESCRIPTION
Request at most two jobs for get_job so CLI and PySDK can report ambiguous prefixes instead of silently picking the first match.