### PR TITLE
build: install cargo-edit only in the release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,6 +115,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: ./.github/actions/setup-caches
       - name: Compute version bump
         id: bump
         run: |
@@ -123,6 +124,8 @@ jobs:
           echo "current_version=${current}" >> "$GITHUB_OUTPUT"
           echo "bumped_version=${bump}" >> "$GITHUB_OUTPUT"
           echo "Current: ${current}, bump: ${bump}"
+      - name: Install cargo-edit
+        run: cargo install cargo-edit@0.13 --locked
       - name: Prepare release
         id: prepare
         if: steps.bump.outputs.current_version != steps.bump.outputs.bumped_version

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,5 @@
 [tools]
 buf = "1"
-"cargo:cargo-edit" = "0.13"
 git-cliff = "2"
 bun = "1.2.18"
 just = "latest"


### PR DESCRIPTION
The 0.1.13 release failed building the linux/arm64 wheel. cargo-edit was a global mise tool, so mise-action tried to build it on every runner, and the arm64 image ships rustc 1.91, below cargo-edit 0.13.11's 1.92 minimum.

cargo-edit is only used by `cargo set-version` in the release PR job, so I install it there instead of having every build pull it in. The wheel build runners no longer touch it.

Failed run:
- https://github.com/BauplanLabs/bauplan/actions/runs/27538507248/job/81400778836