### PR TITLE
build: pass --unreleased to git cliff

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,7 +118,7 @@ jobs:
       - name: Compute version bump
         id: bump
         run: |
-          bump=$(git-cliff --bumped-version)
+          bump=$(git-cliff --bumped-version --unreleased)
           current=v$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name=="bauplan") | .version')
           echo "current_version=${current}" >> "$GITHUB_OUTPUT"
           echo "bumped_version=${bump}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
In local testing, `--bumped-version` without `--unreleased` is a noop, because it can't "see" the commits that would make up the bumped version. This seems like questionable UX, but what do I know.