### PR TITLE
fix(cli): align checkout -b tip and help with real behavior

### DIFF
--- a/src/cli/branch.rs
+++ b/src/cli/branch.rs
@@ -334,9 +334,9 @@ fn create_branch(cli: &Cli, args: BranchCreateArgs) -> anyhow::Result<()> {
 
     eprintln!("Created branch \"{branch_name}\"");
     anstream::eprintln!(
-        "{GREEN}TIP:{GREEN:#} To create and switch to a branch in one command, run:",
+        "{GREEN}TIP:{GREEN:#} To switch to the new branch, run:",
     );
-    eprintln!("\tbauplan checkout -b {branch_name:?}");
+    eprintln!("\tbauplan checkout {branch_name:?}");
     Ok(())
 }
 

--- a/src/cli/checkout.rs
+++ b/src/cli/checkout.rs
@@ -19,7 +19,7 @@ use crate::cli::{Cli, color::CliExamples, yaml};
 pub(crate) struct CheckoutArgs {
     /// Branch name
     pub branch_name: String,
-    /// Create the branch first (equivalent to "branch create --if-not-exists")
+    /// Create the branch before switching (fails if it already exists)
     #[arg(short = 'b')]
     pub create: bool,
     /// Ref from which to create when using -b. If not specified,


### PR DESCRIPTION
This fixes the two problems reported in #241.

The tip printed after `bauplan branch create` suggested running `bauplan checkout -b "<name>"`, but the branch had just been created, so that command always failed with `BRANCH_EXISTS`. I changed the tip to suggest plain `bauplan checkout "<name>"`, which just switches to the branch that already exists.

I also fixed the help text for the `-b` flag. It claimed to be equivalent to `branch create --if-not-exists`, but the command actually fails when the branch already exists. The help now describes the real behavior instead.

I did not change the behavior of `-b` itself: failing when the branch already exists is the intended, git-like behavior.

Closes #241