### PR TITLE
test: remove fixtures which use intermediate SQL models

### DIFF
--- a/tests/fixtures/multiparent/model_3.sql
+++ b/tests/fixtures/multiparent/model_3.sql
@@ -1,1 +1,0 @@
-SELECT col_2 AS col_3 FROM model_2

--- a/tests/fixtures/multiparent/models.py
+++ b/tests/fixtures/multiparent/models.py
@@ -1,5 +1,18 @@
 import bauplan
 
+
+@bauplan.model(
+    columns=['col_3'],
+    materialization_strategy='NONE',
+)
+@bauplan.python('3.11')
+def model_3(
+    model_2=bauplan.Model('model_2', columns=['col_2']),
+):
+    import pyarrow as pa
+    return pa.Table.from_pydict({'col_3': model_2['col_2']})
+
+
 @bauplan.model(
     columns=['col_2'],
     materialization_strategy='NONE',
@@ -40,7 +53,7 @@ def model_4(
     assert val_2_0 == 'val_0'
     assert val_2_1 == 'val_1'
 
-    # the same cause we select col_2 AS col_3 in the SQL model, model_3
+    # model_3 renames col_2 to col_3, so values should match
     assert val_3_0 == 'val_0'
     assert val_3_1 == 'val_1'
 

--- a/tests/fixtures/prophet/models.py
+++ b/tests/fixtures/prophet/models.py
@@ -44,6 +44,24 @@ def normalize_data(
 
 
 @bauplan.model(
+    columns=['ds', 'y'],
+    materialization_strategy='NONE',
+)
+@bauplan.python('3.11', pip={'pandas': '2.2.2'})
+def training_dataset(
+    data=bauplan.Model(
+        'normalize_data',
+        columns=['ds'],
+    ),
+):
+    import pandas as pd
+    df = data.to_pandas()
+    result = df.groupby('ds').size().reset_index(name='y')
+    result = result.sort_values('ds').reset_index(drop=True)
+    return result
+
+
+@bauplan.model(
     columns=[
         'ds',
         'yhat',

--- a/tests/fixtures/prophet/training_dataset.sql
+++ b/tests/fixtures/prophet/training_dataset.sql
@@ -1,8 +1,0 @@
--- bauplan: materialization_strategy = NONE
-SELECT
-    ds,
-    COUNT(*) AS y
-FROM
-    normalize_data
-GROUP BY ds
-ORDER BY ds ASC


### PR DESCRIPTION
Support for this (currently done via SQLGlot and the old runtime) is going away with the new infrastructure. This removes the tests that depend on that behavior in advance.