### PR TITLE
build: skip cargo-edit reinstall when already cached

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,7 +125,8 @@ jobs:
           echo "bumped_version=${bump}" >> "$GITHUB_OUTPUT"
           echo "Current: ${current}, bump: ${bump}"
       - name: Install cargo-edit
-        run: cargo install cargo-edit --locked --version "^0.13"
+        # Skip if already restored from the cached ~/.cargo/bin.
+        run: command -v cargo-set-version >/dev/null || cargo install cargo-edit --locked --version "^0.13"
       - name: Prepare release
         id: prepare
         if: steps.bump.outputs.current_version != steps.bump.outputs.bumped_version


### PR DESCRIPTION
setup-caches restores ~/.cargo/bin, so cargo-edit's binaries can already be present and `cargo install` aborts with "binary already exists". 
Guard the install on cargo-set-version so cached runs skip it instead of failing.
https://github.com/BauplanLabs/bauplan/actions/runs/27805710591/job/82285002441