### PR TITLE
feat(docs): hosted mcp

### DIFF
--- a/docs/pages/agents/overview.mdx
+++ b/docs/pages/agents/overview.mdx
@@ -19,7 +19,11 @@ Through the MCP server, an assistant can:
 - Run Bauplan projects and pipelines
 - Track and inspect jobs
 
-The MCP server is primarily intended for connection to non-technical tools such as Claude Desktop or the ChatGPT app, where an assistant needs live access to lakehouse state. For setup instructions, configuration examples, and usage videos, visit the repository.
+The MCP server works with any MCP-capable assistant that needs live access to lakehouse state, from non-technical apps like Claude Desktop or the ChatGPT app to coding agents like Claude Code and Codex.
+
+You can run the server yourself, or connect to Bauplan's **hosted MCP endpoint** and authenticate with your Bauplan API key.
+
+For the endpoint URL, setup instructions, configuration examples, and usage videos, visit the repository.
 
 See: [https://github.com/BauplanLabs/bauplan-mcp-server](https://github.com/BauplanLabs/bauplan-mcp-server)
 


### PR DESCRIPTION
Adding a note to Agents/Overview page that hosted mcp version is now available.