### PR TITLE
chore(pysdk): remove the unsupported synthetic_model decorator

### DIFF
--- a/gen-stubs/src/__init__.pyi
+++ b/gen-stubs/src/__init__.pyi
@@ -32,7 +32,6 @@ from bauplan._decorators import (
     model,
     python,
     resources,
-    synthetic_model,
 )
 from bauplan._parameters import Parameter
 
@@ -62,5 +61,4 @@ __all__ = [
     "model",
     "python",
     "resources",
-    "synthetic_model",
 ]

--- a/python/bauplan/__init__.py
+++ b/python/bauplan/__init__.py
@@ -21,7 +21,6 @@ from bauplan._decorators import (
     model,
     python,
     resources,
-    synthetic_model,
 )
 from bauplan._parameters import Parameter
 
@@ -52,5 +51,4 @@ __all__ = [
     "model",
     "python",
     "resources",
-    "synthetic_model",
 ]

--- a/python/bauplan/__init__.pyi
+++ b/python/bauplan/__init__.pyi
@@ -32,7 +32,6 @@ from bauplan._decorators import (
     model,
     python,
     resources,
-    synthetic_model,
 )
 from bauplan._parameters import Parameter
 
@@ -62,7 +61,6 @@ __all__ = [
     "model",
     "python",
     "resources",
-    "synthetic_model",
 ]
 
 import pathlib

--- a/python/bauplan/_decorators.py
+++ b/python/bauplan/_decorators.py
@@ -112,29 +112,6 @@ def expectation(
     return decorator
 
 
-def synthetic_model(
-    name: str,
-    columns: List[str],
-    **kwargs: Any,
-) -> Callable:
-    """
-    Decorator that defines a Bauplan Synthetic Model.
-
-    Parameters:
-        name: The name of the model. Defaults to the function name.
-        columns: The columns of the synthetic model (e.g. ``['id', 'name', 'email']``).
-    """
-
-    def decorator(f: Callable) -> Callable:
-        @functools.wraps(f)
-        def wrapper(*args, **kwargs) -> Any:
-            return f(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
-
-
 def python(
     version: Optional[str] = None,
     pip: Optional[Dict[str, str]] = None,


### PR DESCRIPTION
The `synthetic_model` decorator was declared and exported but never actually supported by bauplan;
I removed the definition and its public exports from the SDK and the stub files so the api only advertises what we really support.