### PR TITLE
Longbow client tweaks

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -222,6 +222,7 @@ pub(crate) async fn monitor_job_progress(
     let stream = client.monitor_job(monitor_req, Arc::clone(&endpoint));
     futures::pin_mut!(stream);
 
+    let mut outcome = None;
     loop {
         let res = tokio::select! {
             v = stream.try_next() => v,
@@ -234,7 +235,7 @@ pub(crate) async fn monitor_job_progress(
 
         let event = match res {
             Ok(Some(v)) => v,
-            Ok(None) => bail!("no JobCompletion event found"),
+            Ok(None) => break,
             Err(ref e)
                 if e.code() == tonic::Code::Cancelled
                     || e.code() == tonic::Code::DeadlineExceeded =>
@@ -262,15 +263,17 @@ pub(crate) async fn monitor_job_progress(
                 handler(event);
             }
             RunnerEvent::JobCompletion(ev) => {
-                if let Some(ep) = endpoint.get() {
-                    ep.close().await;
-                }
-
-                return Ok(grpc::interpret_outcome(ev.outcome)?);
+                outcome = ev.outcome;
             }
             _ => handler(event),
         }
     }
+
+    if let Some(ep) = endpoint.get() {
+        ep.close().await;
+    }
+
+    Ok(grpc::interpret_outcome(outcome)?)
 }
 
 async fn handle_run(cli: &Cli, args: RunArgs) -> anyhow::Result<()> {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -384,45 +384,35 @@ async fn handle_run(cli: &Cli, args: RunArgs) -> anyhow::Result<()> {
                     return;
                 };
 
-                if metadata.level() != commanderpb::task_metadata::TaskLevel::Dag {
-                    return;
-                }
-
-                let task_id = ev.task_id;
-                let mut spinners = spinners.borrow_mut();
-                let task_spinner = spinners
-                    .entry(task_id.clone())
-                    .or_insert_with(|| cli.new_spinner());
-                task_spinner.enable_steady_tick(time::Duration::from_millis(100));
-
-                // Indent the task name to present a hierarchy.
-                // TODO: maybe we can replicate the DAG hierarchy here a bit?
-                let name = if metadata.task_type == "USER_CODE_EXPECTATION" {
-                    let name = metadata.function_name.unwrap_or(ev.task_name);
-                    task_spinner.set_message(format!("{CYAN}  {name} [expectation]{CYAN:#}"));
-                    name
-                } else {
-                    let name = metadata.model_name.unwrap_or(ev.task_name);
-                    task_spinner.set_message(format!("{BLUE}  {name}{BLUE:#}"));
-                    name
-                };
-
-                summary.tasks.push(TaskSummary {
-                    task_id,
-                    description: metadata.human_readable_task_type,
-                    name,
-                    file_name: metadata.file_name,
-                    line_number: metadata.line_number.map(|x| x as _),
-                    started: Utc::now(),
-                    ended: Utc::now(),
-                    outcome: SummaryOutcome::Success,
-                });
+                add_task(
+                    cli,
+                    &spinners,
+                    &mut summary,
+                    ev.task_id,
+                    ev.task_name,
+                    metadata,
+                );
             }
             RunnerEvent::TaskCompletion(ev) => {
                 use commanderpb::task_complete_event::Outcome;
                 let Some(outcome) = ev.outcome else {
                     return;
                 };
+
+                let Some(metadata) = ev.task_metadata else {
+                    return;
+                };
+
+                // Register the task, just in case we didn't get a TaskStarted
+                // event for it (this happens for skipped tasks, for example).
+                add_task(
+                    cli,
+                    &spinners,
+                    &mut summary,
+                    ev.task_id.clone(),
+                    ev.task_name,
+                    metadata,
+                );
 
                 // Finish the task spinner.
                 if let Some(task_spinner) = spinners.borrow().get(ev.task_id.as_str()) {
@@ -527,6 +517,51 @@ async fn handle_run(cli: &Cli, args: RunArgs) -> anyhow::Result<()> {
     }
 
     res
+}
+
+fn add_task(
+    cli: &Cli,
+    spinners: &RefCell<BTreeMap<String, ProgressBar>>,
+    summary: &mut Summary,
+    task_id: String,
+    task_name: String,
+    metadata: commanderpb::TaskMetadata,
+) {
+    if metadata.level() != commanderpb::task_metadata::TaskLevel::Dag {
+        return;
+    }
+
+    let mut spinners = spinners.borrow_mut();
+    if spinners.contains_key(&task_id) {
+        return;
+    }
+
+    let task_spinner = spinners
+        .entry(task_id.clone())
+        .or_insert_with(|| cli.new_spinner());
+    task_spinner.enable_steady_tick(time::Duration::from_millis(100));
+
+    // Indent the task name to present a hierarchy.
+    let name = if metadata.task_type == "USER_CODE_EXPECTATION" {
+        let name = metadata.function_name.unwrap_or(task_name);
+        task_spinner.set_message(format!("{CYAN}  {name} [expectation]{CYAN:#}"));
+        name
+    } else {
+        let name = metadata.model_name.unwrap_or(task_name);
+        task_spinner.set_message(format!("{BLUE}  {name}{BLUE:#}"));
+        name
+    };
+
+    summary.tasks.push(TaskSummary {
+        task_id,
+        description: metadata.human_readable_task_type,
+        name,
+        file_name: metadata.file_name,
+        line_number: metadata.line_number.map(|x| x as _),
+        started: Utc::now(),
+        ended: Utc::now(),
+        outcome: SummaryOutcome::Success,
+    });
 }
 
 fn print_dag(job_id: &str, dag_ascii: String) -> anyhow::Result<()> {

--- a/src/grpc/job.rs
+++ b/src/grpc/job.rs
@@ -306,11 +306,12 @@ enum Stdio {
 /// encounters a TaskStartEvent with a nonempty `longbow_public_key`, it spawns
 /// a task to to push log lines into the event stream in parallel.
 pub(super) struct JobEventStream {
-    inner: tonic::Streaming<SubscribeLogsResponse>,
+    inner: Option<tonic::Streaming<SubscribeLogsResponse>>,
     longbow_output_rx: tokio::sync::mpsc::UnboundedReceiver<((String, Stdio), String)>,
     longbow_output_tx: tokio::sync::mpsc::UnboundedSender<((String, Stdio), String)>,
     endpoint: Arc<tokio::sync::OnceCell<iroh::Endpoint>>,
     task_metadata: BTreeMap<String, TaskMetadata>,
+    task_connections: tokio::task::JoinSet<()>,
 }
 
 impl JobEventStream {
@@ -320,11 +321,12 @@ impl JobEventStream {
     ) -> Self {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         Self {
-            inner,
+            inner: Some(inner),
             longbow_output_rx: rx,
             longbow_output_tx: tx,
             endpoint,
             task_metadata: BTreeMap::new(),
+            task_connections: tokio::task::JoinSet::new(),
         }
     }
 }
@@ -349,7 +351,7 @@ impl JobEventStream {
         let tx = self.longbow_output_tx.clone();
         let endpoint = self.endpoint.clone();
 
-        tokio::spawn(async move {
+        self.task_connections.spawn(async move {
             let preset = BauplanPreset::default();
             let addr = preset.add_relay_urls(iroh::EndpointAddr::new(public_key));
 
@@ -408,9 +410,40 @@ impl futures::Stream for JobEventStream {
         let this = self.get_mut();
 
         loop {
-            if let Poll::Ready(v) = Pin::new(&mut this.inner).poll_next(cx) {
+            // Clear the JoinSet.
+            if !this.task_connections.is_empty()
+                && let Poll::Ready(Some(v)) = this.task_connections.poll_join_next(cx)
+            {
+                if let Err(e) = v {
+                    error!(err = %e, "failed to read task output");
+                }
+
+                continue;
+            }
+
+            // The order here is intentional, to make sure we drain the output
+            // before exiting.
+            if let Poll::Ready(v) = this.longbow_output_rx.poll_recv(cx) {
+                let Some(((task_id, stdio), line)) = v else {
+                    continue;
+                };
+
+                let metadata = this.task_metadata.get(&task_id);
+                let ev = synthetic_line_event(metadata, stdio, line);
+                return Poll::Ready(Some(Ok(ev)));
+            } else if let Some(inner) = this.inner.as_mut()
+                && let Poll::Ready(v) = Pin::new(inner).poll_next(cx)
+            {
                 let Some(resp) = v else {
-                    return Poll::Ready(None);
+                    // The stream has ended. If there are still longbow
+                    // connection tasks, wait for those. Otherwise, we could
+                    // exit before printing all the output for those tasks.
+                    this.inner.take();
+                    if this.task_connections.is_empty() {
+                        return Poll::Ready(None);
+                    } else {
+                        return Poll::Pending;
+                    }
                 };
 
                 let resp = resp?;
@@ -428,14 +461,10 @@ impl futures::Stream for JobEventStream {
                 }
 
                 return Poll::Ready(Some(Ok(event)));
-            } else if let Poll::Ready(v) = this.longbow_output_rx.poll_recv(cx) {
-                let Some(((task_id, stdio), line)) = v else {
-                    continue;
-                };
+            }
 
-                let metadata = this.task_metadata.get(&task_id);
-                let ev = synthetic_line_event(metadata, stdio, line);
-                return Poll::Ready(Some(Ok(ev)));
+            if this.inner.is_none() && this.task_connections.is_empty() {
+                return Poll::Ready(None);
             }
 
             return Poll::Pending;


### PR DESCRIPTION
This fixes two issues:

 - If tasks are skipped and no TaskStartedEvent is sent, the tasks wouldn't display as spinners at all in the CLI.
 - If the job ended before the tasks' output was drained, we wouldn't get a chance to see it.