### PR TITLE
fix(cli): trust the bundled mozilla roots so tls works on fresh windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5998,6 +5998,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,11 @@ globset = "0.4.18"
 ignore = "0.4.26"
 tokio-util = { version = "0.7.18", features = ["codec"] }
 
+# Windows delivers root certificates on demand via CryptoAPI, which
+# rustls-native-certs never invokes, so we also bundle the Mozilla roots there.
+[target.'cfg(windows)'.dependencies]
+tonic = { version = "0.14", features = ["tls-webpki-roots"] }
+
 [build-dependencies]
 anyhow = "1"
 tonic-prost-build = "0.14"

--- a/src/flight.rs
+++ b/src/flight.rs
@@ -25,7 +25,7 @@ pub async fn fetch_flight_results(
     impl Stream<Item = FlightResult<RecordBatch>> + use<>,
 )> {
     let channel = Channel::builder(endpoint)
-        .tls_config(ClientTlsConfig::new().with_native_roots())
+        .tls_config(ClientTlsConfig::new().with_enabled_roots())
         .unwrap()
         .timeout(client_timeout)
         .connect_lazy();

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -46,7 +46,7 @@ impl Client {
     ) -> Result<Self, tonic::transport::Error> {
         let api_endpoint = profile.api_endpoint.clone();
         let channel = Channel::builder(api_endpoint)
-            .tls_config(ClientTlsConfig::new().with_native_roots())?
+            .tls_config(ClientTlsConfig::new().with_enabled_roots())?
             .timeout(timeout)
             .user_agent(&profile.user_agent)?
             .connect_lazy();


### PR DESCRIPTION
On fresh Windows machines every gRPC call failed with `invalid peer certificate: UnknownIssuer`.

Windows does not preinstall all root CAs; it downloads them on demand (including `Amazon Root CA 1`, which signs our ACM certificates), but only when the validation goes through the native CryptoAPI.

Our HTTP calls were already safe because ureq uses the platform verifier; the tonic channels instead use `with_native_roots()`, which only takes a snapshot of the Windows store and never triggers that download, so on a fresh machine the Amazon root is simply not there.

The fix adds the Mozilla bundle (`webpki-roots`) on top of the native roots for the two tonic channels (commander and flight): the bundle ships the Amazon roots, so the handshake works even when the store was never populated. We keep the native roots too, so corporate proxies with custom CAs keep working.

The bundle is gated to Windows (`cfg` plus a per-target feature), so linux and mac keep exactly the same trust store as before.