### PR TITLE
docs: improve seo - home page

### DIFF
--- a/docs/pages/tutorial/index.mdx
+++ b/docs/pages/tutorial/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Welcome to Bauplan"
+title: "Bauplan - The Git-for-Data Lakehouse"
 description: "Bauplan brings Git-style branching to data so agents can safely change production Iceberg tables, validate, publish to main atomically, and roll back on failure."
 sidebar_label: "Home"
 slug: "/"
@@ -7,7 +7,9 @@ slug: "/"
 
 import { HomePage } from "@site/src/theme/components/home/index";
 
-Bauplan brings Git-style workflows to data so AI agents can safely make changes on your data.
+Bauplan is a Git-for-data lakehouse that brings Git-style workflows to your data, so AI agents can safely make changes on real production tables.
+
+It runs your Python and SQL pipelines directly on Apache Iceberg tables, with no servers or clusters to manage.
 
 You can run AI-generated pipeline changes on real production datasets while keeping your data and downstream applications protected, with a clean rollback path if something goes wrong.
 


### PR DESCRIPTION
## Changes
`docs/pages/tutorial/index.mdx`:
- **H1/`<title>`:** `Welcome to Bauplan` → `Bauplan - The Git-for-Data Lakehouse`
- **Body:** reworded the opener + added one Python/SQL/Iceberg sentence (244 → ~270 words)

## Why
- **Title keywords:** the `<title>`/H1 are the strongest on-page relevance signals and the most prominent text on the page. `Welcome to` is filler that ranks for nothing; the new title leads with terms we want (`Git-for-Data`, `Lakehouse`).
- **Word count:** ~250+ words is the common baseline for a page to read as substantive rather than thin; we were at 244.