### PR TITLE
docs: pin ruff version <0.16

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -80,7 +80,7 @@ pub(crate) fn handle(args: InitArgs) -> anyhow::Result<()> {
     //
     // [dependency-groups]
     // dev = [
-    //     "ruff>=0.15",
+    //     "ruff>=0.15,<0.16",
     //     "ty>=0.0.48",
     //     "polars>=1"
     // ]
@@ -103,7 +103,8 @@ pub(crate) fn handle(args: InitArgs) -> anyhow::Result<()> {
     dependency_groups.insert(
         "dev".into(),
         toml::Value::Array(vec![
-            toml::Value::String("ruff>=0.15".into()),
+            // ruff 0.16 enables B008 by default, which errors when we use the default argument position for `bauplan.Model()`.
+            toml::Value::String("ruff>=0.15,<0.16".into()),
             toml::Value::String("ty>=0.0.48".into()),
             toml::Value::String("polars>=1".into()),
         ]),


### PR DESCRIPTION
## Pin ruff version to below 0.16

ruff 0.16 breaks our CI tests for the docs because of the [B008](https://docs.astral.sh/ruff/rules/function-call-in-default-argument/) rule set by default, pinning a lower version to prevent the problem. This fixes docs CI pipeline.