### PR TITLE
fix(pysdk): describe query results with the schema of the batches

### DIFF
--- a/src/flight.rs
+++ b/src/flight.rs
@@ -1,6 +1,6 @@
 //! Support for fetching query results via Arrow Flight.
 
-use std::time;
+use std::{sync::Arc, time};
 
 use arrow::{array::RecordBatch, datatypes::Schema};
 use arrow_flight::{
@@ -113,6 +113,15 @@ async fn fetch_batches(
     Ok(stream)
 }
 
+/// The schema to describe the results with. The one advertised with them is not
+/// always the one the batches carry, so prefer the batches when there are any.
+pub fn result_schema(batch: Option<&RecordBatch>, advertised: Schema) -> Arc<Schema> {
+    match batch {
+        Some(batch) => batch.schema(),
+        None => Arc::new(advertised),
+    }
+}
+
 /// Truncates a stream of record batches to at most `row_limit` rows total.
 pub fn limit_rows<E>(
     stream: impl Stream<Item = Result<RecordBatch, E>>,
@@ -153,7 +162,6 @@ mod tests {
     use super::*;
 
     use arrow::datatypes::{DataType, Field};
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_enforce_row_limit() -> anyhow::Result<()> {
@@ -170,5 +178,19 @@ mod tests {
         let row_counts: Vec<_> = batches.iter().map(|b| b.num_rows()).collect();
         assert_eq!(row_counts, vec![3, 1]);
         Ok(())
+    }
+
+    #[test]
+    fn test_result_schema_prefers_the_batches() {
+        let advertised = Schema::new(vec![Field::new("x", DataType::LargeUtf8, true)]);
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Utf8, true)]));
+        let array = arrow::array::StringArray::from(vec!["a"]);
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(array)]).unwrap();
+
+        assert_eq!(result_schema(Some(&batch), advertised.clone()), schema);
+        assert_eq!(
+            result_schema(None, advertised.clone()),
+            Arc::new(advertised)
+        );
     }
 }

--- a/src/python/query.rs
+++ b/src/python/query.rs
@@ -203,7 +203,13 @@ impl Client {
             .await?;
 
         futures::pin_mut!(batches);
-        let mut writer = open(Arc::new(schema)).map_err(query_err)?;
+
+        let first = batches.try_next().await?;
+        let mut writer = open(flight::result_schema(first.as_ref(), schema)).map_err(query_err)?;
+
+        if let Some(batch) = first {
+            writer.write(&batch).map_err(query_err)?;
+        }
 
         loop {
             let Some(batch) = batches.try_next().await? else {
@@ -309,7 +315,8 @@ impl Client {
                 .await?;
 
             let batches: Vec<RecordBatch> = stream.try_collect().await?;
-            pyo3_arrow::PyTable::try_new(batches, Arc::new(schema))
+            let schema = flight::result_schema(batches.first(), schema);
+            pyo3_arrow::PyTable::try_new(batches, schema)
         })?;
 
         Ok(table.into_pyarrow(py)?.unbind())
@@ -743,7 +750,8 @@ impl Client {
                 .await?;
 
             let batches: Vec<RecordBatch> = stream.try_collect().await?;
-            pyo3_arrow::PyTable::try_new(batches, Arc::new(schema))
+            let schema = flight::result_schema(batches.first(), schema);
+            pyo3_arrow::PyTable::try_new(batches, schema)
         })?;
 
         Ok(table.into_pyarrow(py)?.unbind())


### PR DESCRIPTION
The flight server advertises a schema that does not always match the batches it sends, so any query returning a list column failed to build the table.