### PR TITLE
docs: fix video thumbnail, admonitions on brand, surface agent docs earlier

### DIFF
--- a/docs/pages/agents/skills.mdx
+++ b/docs/pages/agents/skills.mdx
@@ -34,8 +34,8 @@ Bauplan Skills can be installed in Claude Code using the instructions in this [v
 
 Bauplan Skills can be installed in Codex using the instructions in this [video](https://youtu.be/TD7gME7JnZw?t=180), or by following these steps inside Codex to run the skill installer pointing at the Bauplan skills directory:
 
-```
-$skill-installer https://github.com/BauplanLabs/bauplan-skills/tree/main/plugins/bauplan/skills
+```sh
+skill-installer https://github.com/BauplanLabs/bauplan-skills/tree/main/plugins/bauplan/skills
 ```
 
 Codex will fetch and install the Bauplan skills automatically. Restart Codex once the installer completes.

--- a/docs/pages/tutorial/01-quick-start.mdx
+++ b/docs/pages/tutorial/01-quick-start.mdx
@@ -5,12 +5,16 @@ description: "Get started with Bauplan. Create a data branch, scaffold a project
 
 ## Prerequisites
 
+- Python 3.11 or higher.
 - [Install](/tutorial/installation) bauplan.
 
-<Note>
-  Bauplan requires Python 3.11 or higher. Make sure you have a compatible Python
-  version installed before proceeding.
-</Note>
+{/* prettier-ignore */}
+<CollapsibleTip summary="Rather get started with an AI agent?">
+- Install the [Bauplan
+Skills](/agents/skills). 
+- See [Agents](/agents/overview) for the
+other ways to connect an assistant to your lakehouse.
+</CollapsibleTip>
 
 ## Create a branch
 

--- a/docs/sidebar.js
+++ b/docs/sidebar.js
@@ -22,6 +22,12 @@ export default {
     },
     {
       type: "category",
+      label: "Agents",
+      collapsed: true,
+      items: ["agents/overview", "agents/skills", "agents/mcp", "agents/context"],
+    },
+    {
+      type: "category",
       label: "Platform Overview",
       collapsed: true,
       link: {
@@ -61,12 +67,6 @@ export default {
           ],
         },
       ],
-    },
-    {
-      type: "category",
-      label: "Agents",
-      collapsed: true,
-      items: ["agents/overview", "agents/skills", "agents/mcp", "agents/context"],
     },
     {
       type: "category",

--- a/docs/src/css/global.css
+++ b/docs/src/css/global.css
@@ -205,19 +205,23 @@ a:has(> code):hover code {
   background: rgba(255, 252, 227, 1);
 }
 
-/* Inline code inside admonitions: force opaque background so the
-   admonition's own background doesn't bleed through the code pill. */
-.theme-admonition code {
+/* Admonitions accent in brand colors*/
+.alert--warning {
+  --ifm-alert-border-color: #FFD600;
+  --contrast-foreground: #554700;
+}
+
+.alert--success {
+  --ifm-alert-border-color: var(--ifm-color-primary);
+  --contrast-foreground: #003B55;
+}
+
+.theme-admonition :not(pre) > code {
   background: var(--ifm-code-background);
 }
 
 .theme-admonition a:has(> code) {
   text-decoration: none;
-}
-
-[data-theme='dark'] .theme-admonition code {
-  background: rgb(255, 252, 227);
-  color: #000;
 }
 
 footer {
@@ -285,6 +289,22 @@ hr.mermaid {
 
 [data-theme='dark'] code a {
   color: #000000;
+}
+
+/* Admonitions */
+[data-theme='dark'] .alert--success {
+  --ifm-alert-border-color: var(--ifm-color-primary);
+  --ifm-alert-foreground-color: #E6F7FF;
+}
+
+[data-theme='dark'] .alert--warning {
+  --ifm-alert-border-color: #FFD600;
+  --ifm-alert-foreground-color: #FFFDE6;
+}
+
+[data-theme='dark'] .theme-admonition :not(pre) > code {
+  background: rgb(255, 252, 227);
+  color: #000;
 }
 
 /* navbar */

--- a/docs/src/theme/components/VideoCard.js
+++ b/docs/src/theme/components/VideoCard.js
@@ -1,7 +1,9 @@
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import { Play } from "lucide-react";
 
 const PLAYER_ORIGIN = "https://www.youtube-nocookie.com";
+
+const thumbnailUrl = (id, size) => `https://i.ytimg.com/vi/${id}/${size}.jpg`;
 
 export function VideoCardGrid({ children }) {
   return <div className="grid md:grid-cols-3 gap-4 mb-6">{children}</div>;
@@ -9,6 +11,16 @@ export function VideoCardGrid({ children }) {
 
 export function VideoCard({ id, title, duration, blurb, start }) {
   const [playing, setPlaying] = useState(false);
+  const [thumbnail, setThumbnail] = useState(thumbnailUrl(id, "maxresdefault"));
+
+  const rejectPlaceholder = useCallback(
+    (img) => {
+      if (img?.complete && img.naturalWidth <= 120) {
+        setThumbnail(thumbnailUrl(id, "hqdefault"));
+      }
+    },
+    [id],
+  );
 
   const params = new URLSearchParams({ rel: "0", autoplay: "1" });
   if (start) {
@@ -42,10 +54,10 @@ export function VideoCard({ id, title, duration, blurb, start }) {
             className="group absolute inset-0 h-full w-full cursor-pointer border-0 bg-transparent p-0"
           >
             <img
-              src={`https://i.ytimg.com/vi/${id}/maxresdefault.jpg`}
-              onError={(e) => {
-                e.currentTarget.src = `https://i.ytimg.com/vi/${id}/mqdefault.jpg`;
-              }}
+              ref={rejectPlaceholder}
+              src={thumbnail}
+              onLoad={(e) => rejectPlaceholder(e.currentTarget)}
+              onError={() => setThumbnail(thumbnailUrl(id, "hqdefault"))}
               alt=""
               loading="lazy"
               className="absolute inset-0 h-full w-full object-cover"


### PR DESCRIPTION
Mattia made some comments and suggestions on a call today, so implementing some of the stuff he mentioned and a couple of small fixes I noticed:

- One of the videos on the home page had a grey thumbnail. VideoCard now falls back to the `hqdefault` thumbnail when `maxresdefault` is missing.
- Admonitions used Docusaurus' default green and yellow; success and warning now use the brand blue and yellow.
- Moved the Python 3.11 requirement to the prerequisites list, and used the space for a collapsible tip linking to Bauplan Skills and the agent overview.
- Moved the Agents category above Platform Overview in the sidebar, and dropped the stray `$` from the skill-installer command so it can be copy-pasted.