### PR TITLE
[Quickstart] Remove comments from codeblocks, reorganize section ordering, small language cleanup 

### DIFF
--- a/docs/pages/tutorial/01-quick-start.mdx
+++ b/docs/pages/tutorial/01-quick-start.mdx
@@ -18,28 +18,28 @@ other ways to connect an assistant to your lakehouse.
 
 ## Create a branch
 
-Create an isolated [data branch](/concepts/git-for-data/data-branches) to work in - like a git branch, but for your lakehouse:
+Create a new [data branch](/concepts/git-for-data/data-branches) and switch to it:
 
 ```sh
-bauplan checkout -b <YOUR_USERNAME>.quickstart # create a new branch, and switch to it
+bauplan checkout -b <YOUR_USERNAME>.quickstart
 ```
 
 ## Explore the data
 
-Bauplan sandbox comes with pre-loaded public datasets. This command will show you the tables in your checked out branch.
+Examine public datasets pre-loaded into the Bauplan sandbox; `table ls` will show you the tables in your checked out branch (newly created branches inherit all tables from the parent branch).
 
 ```sh
 bauplan table ls
 ```
 
-You will see a list of tables, this is because a newly created branch inherits all previously existing tables from its parent branch.
-Before getting into our project, let's explore the schema of the table we're going to be working with:
+You should see a list of tables. Let's explore the schema of the table we're going to work with:
 
 ```sh
 bauplan table get titanic
 ```
 
 You'll see the table's columns and their types - this is the input our pipeline will transform.
+
 
 ## Scaffold a project
 
@@ -89,10 +89,10 @@ This tells Bauplan to write (and fully replace on each run) the model's output a
 bauplan run
 ```
 
-You can confirm the table is persisted by running:
+You can confirm the table is persisted by running the following command (only 10 rows will show by default):
 
 ```sh
-bauplan query "SELECT * FROM survival_rate_by_age" # only 10 rows are shown by default
+bauplan query "SELECT * FROM survival_rate_by_age"
 ```
 
 Learn more about materialization strategies and models [here](/concepts/models).


### PR DESCRIPTION
A few changes: 

1. It's common for developers hit the "copy" button on codeblocks. Removing the comments so the commands run effectively
2. Edited some of the language around data exploration
3. Simplified language surrounding data branch (easily maps to git concepts without the explicit explanation)

Maintainers, please feel free to make changes to any or all of this to make it acceptable to merge or simply close the PR! Thanks