### PR TITLE
Avoid deletion of checked-out branch

### DIFF
--- a/src/cli/branch.rs
+++ b/src/cli/branch.rs
@@ -333,9 +333,7 @@ fn create_branch(cli: &Cli, args: BranchCreateArgs) -> anyhow::Result<()> {
     }
 
     eprintln!("Created branch \"{branch_name}\"");
-    anstream::eprintln!(
-        "{GREEN}TIP:{GREEN:#} To switch to the new branch, run:",
-    );
+    anstream::eprintln!("{GREEN}TIP:{GREEN:#} To switch to the new branch, run:");
     eprintln!("\tbauplan checkout {branch_name:?}");
     Ok(())
 }
@@ -347,6 +345,10 @@ fn delete_branch(cli: &Cli, args: BranchRmArgs) -> anyhow::Result<()> {
     } = args;
 
     let req = DeleteBranch { name: &branch_name };
+
+    if cli.profile.active_branch.as_deref().unwrap_or("main") == branch_name.as_str() {
+        bail!("cannot delete the active branch {branch_name:?}");
+    }
 
     if let Err(e) = cli.roundtrip(req) {
         if if_exists && matches!(api_err_kind(&e), Some(ApiErrorKind::BranchNotFound { .. })) {

--- a/tests/cli/branch.rs
+++ b/tests/cli/branch.rs
@@ -1,3 +1,4 @@
+use crate::cli::config::config_set;
 use crate::cli::{bauplan, test_branch, username};
 use predicates::prelude::PredicateBooleanExt as _;
 use predicates::str::{contains, starts_with};
@@ -88,6 +89,32 @@ fn delete_if_exists() {
         .args(["branch", "delete", &branch])
         .assert()
         .failure();
+}
+
+#[test]
+fn delete_checked_out() {
+    let home = tempfile::tempdir().unwrap();
+    let api_key = "bpln_test_key";
+    let api_endpoint = "https://api.use1.adev.bauplanlabs.com";
+    let active_branch = "checked_out_branch";
+
+    // We want to avoid checking out to the new branch.
+    // Instead, we hijack the config so that we set the branch as active,
+    // without really creating it.
+    config_set(&home, "api_endpoint", api_endpoint);
+    config_set(&home, "api_key", api_key);
+    config_set(&home, "active_branch", active_branch);
+
+    bauplan()
+        .env("HOME", home.path())
+        .env("USERPROFILE", home.path())
+        .env_remove("BAUPLAN_PROFILE")
+        .env_remove("BAUPLAN_API_KEY")
+        .env_remove("BAUPLAN_API_ENDPOINT")
+        .args(["branch", "delete", active_branch])
+        .assert()
+        .failure()
+        .stderr(contains("cannot delete the active branch"));
 }
 
 #[test]

--- a/tests/cli/config.rs
+++ b/tests/cli/config.rs
@@ -22,7 +22,7 @@ fn config_set_writes_supported_profile_settings() -> Result<()> {
     Ok(())
 }
 
-fn config_set(home: &tempfile::TempDir, name: &str, value: &str) {
+pub(crate) fn config_set(home: &tempfile::TempDir, name: &str, value: &str) {
     crate::bauplan()
         .env("HOME", home.path())
         .env("USERPROFILE", home.path())


### PR DESCRIPTION
This PR fixes the current behavior which lets users delete the Bauplan branch they are on (see [this](https://github.com/BauplanLabs/bauplan/issues/400)) without raising an error/warning, and causing downstream problem when trying to create a new branch.  

Closes #400.