### PR TITLE
docs: split ci jobs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,10 +39,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
-    name: Deploy
-    permissions:
-      id-token: write # Required for AWS OIDC authentication
+  build:
+    name: Build
     runs-on: blacksmith-16vcpu-ubuntu-2404
     environment: ${{ inputs.environment || 'dev' }}
     steps:
@@ -61,15 +59,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-bun-
 
-      # Configure AWS credentials
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
-        with:
-          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
-          role-session-name: DeployDocsWebsite
-          aws-region: ${{ vars.AWS_REGION }}
-          mask-aws-account-id: false
-
       - name: docusaurus build
         working-directory: ./docs
         env:
@@ -86,6 +75,38 @@ jobs:
       # robots.txt that allows crawling and points crawlers at the sitemap.
       - if: inputs.environment == 'prod'
         run: cp docs/prod-robots.txt /tmp/build/robots.txt
+
+      # Hand the built site to the deploy job.
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: docs-build
+          path: /tmp/build
+          include-hidden-files: true
+          retention-days: 1
+
+  deploy:
+    name: Deploy
+    needs: build
+    # Skip on fork PRs.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      id-token: write # Required for AWS OIDC authentication
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    environment: ${{ inputs.environment || 'dev' }}
+    steps:
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: docs-build
+          path: /tmp/build
+
+      # Configure AWS credentials
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          role-to-assume: ${{ vars.AWS_OIDC_ROLE_ARN }}
+          role-session-name: DeployDocsWebsite
+          aws-region: ${{ vars.AWS_REGION }}
+          mask-aws-account-id: false
 
       - name: aws s3 sync
         run: aws s3 sync /tmp/build s3://${DOCS_S3_BUCKET} --delete

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,10 +13,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test
+  lint:
+    name: Lint
     runs-on: blacksmith-16vcpu-ubuntu-2404
-    environment: test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -29,7 +28,23 @@ jobs:
 
       - uses: ./.github/actions/setup-caches
 
-      - run: mise x -- just test
+      - run: mise x -- just lint
+
+  test-integration:
+    name: Integration Tests
+    # Skip on forked PRs.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    environment: test
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - uses: ./.github/actions/setup-caches
+
+      - run: mise x -- just test-integration
         env:
           BAUPLAN_API_ENDPOINT: https://api.use1.aqa.bauplanlabs.com
           BAUPLAN_API_KEY: ${{ secrets.BAUPLAN_API_KEY }}

--- a/Justfile
+++ b/Justfile
@@ -22,6 +22,8 @@ lint:
     # Lint CI/CD.
     zizmor . --persona pedantic
 
-test: lint
+test-integration:
     cargo test --features _integration-tests -- --test-threads=4
     uv run pytest -v
+
+test: lint test-integration


### PR DESCRIPTION
## Problem
When PRs come from a forked repo - the credentials needed to successfully run CI are missing, so the CI is fails.

## Solution
Splitting up the CI tasks more granularity, so that at least we can run a build tasks on the changes, without the deploy one, and lint without the integrations one. We can run tasks that don't require the credentials and skip the tasks that require them if it's a forked PR.

## Changes:
- tests.yaml: split the test job into lint and test-integration, the latter
skipped on fork PRs.

- docs.yaml: split the deploy job into build, which uploads the site as an
artifact, and deploy, which downloads it and does the AWS work. deploy
holds id-token: write and skips on fork PRs.

- Justfile: add a test-integration recipe.