### PR TITLE
fix: alpha stub dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
-dependencies = ["bauplan-sdk-types~=0.1"]
+dependencies = ["bauplan-sdk-types~=0.1.0a1"]
 
 [project.urls]
 Documentation = "https://docs.bauplanlabs.com/"


### PR DESCRIPTION
Depend on sdk stub starting with alpha version 0.1.0a1