### PR TITLE
chore: bump bauplan-sdk-types to 0.1.0

### DIFF
--- a/bauplan-sdk-types/pyproject.toml
+++ b/bauplan-sdk-types/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "bauplan-sdk-types"
-version = "0.1.0a1"
+version = "0.1.0"
 requires-python = ">=3.11"
 readme = "README.md"
 description = "Type and decorator definitions for authoring Bauplan pipelines"

--- a/uv.lock
+++ b/uv.lock
@@ -538,7 +538,7 @@ dev = [
 
 [[package]]
 name = "bauplan-sdk-types"
-version = "0.1.0a1"
+version = "0.1.0"
 source = { editable = "bauplan-sdk-types" }
 dependencies = [
     { name = "pyarrow" },
@@ -4659,7 +4659,7 @@ name = "pyzmq"
 version = "27.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy'" },
+    { name = "cffi", marker = "implementation_name == 'pypy' and sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e7/8d/5b3d5631c2f4b4b8862f64cd0c9eb777b5710eeb5125b4be8dd0a200a4c0/pyzmq-27.2.0.tar.gz", hash = "sha256:54d4259d1bfae24ecdb5ca79f7acc2eac6c286a02d6a0ae617797cb45f0726d3", size = 292316, upload-time = "2026-08-20T19:08:21.19Z" }
 wheels = [


### PR DESCRIPTION
Bumps stubs from alpha version to first minor version, `0.1.0`.