### PR TITLE
test: drop the filter on a model input from the parameters fixture

### DIFF
--- a/tests/fixtures/parameters/models.py
+++ b/tests/fixtures/parameters/models.py
@@ -55,7 +55,6 @@ def params_are_cool_model(
         Model(
             "query_model",
             projection_schema=TripsPushdown,
-            filter="PULocationID = $location_id",
         ),
     ],
     golden_ratio: Annotated[float, Parameter("golden_ratio")],


### PR DESCRIPTION
A filter on an input that is another model of the pipeline is not a valid syntax; the planner now rejects it instead of dropping it silently.