### PR TITLE
feat: tweaks to the @python decorator and fixtures

### DIFF
--- a/bauplan-sdk-types/src/bauplan_sdk_types/_runtimes.py
+++ b/bauplan-sdk-types/src/bauplan_sdk_types/_runtimes.py
@@ -4,7 +4,7 @@ from typing import Optional, Callable
 
 
 def python(
-    version: Optional[str] = None,
+    version: str,
     pip: Optional[dict[str, str]] = None,
 ) -> Callable:
     """

--- a/tests/fixtures/missing-schema/models.py
+++ b/tests/fixtures/missing-schema/models.py
@@ -26,5 +26,5 @@ def typed_params_model(
             filter="PULocationID = 138",
         ),
     ],
-) -> "Annotated[pyarrow.Table, TestSchemaMisnamed]":  # ty: ignore[unresolved-reference] # noqa: F821
+) -> Annotated[pyarrow.Table, TestSchemaMisnamed]:  # ty: ignore[unresolved-reference] # noqa: F821
     return taxi_trips.slice(length=5).rename_columns(["misnamed_col"])

--- a/tests/fixtures/prophet/expectations.py
+++ b/tests/fixtures/prophet/expectations.py
@@ -10,12 +10,13 @@ from bauplan import (
     TableSchema,
 )
 from bauplan.standard_expectations import expect_column_mean_greater_than
+from models import QueryModelSchema
 
 
 class TripMilesPushdown(TableSchema):
     """The single column the expectation reads from query_model."""
 
-    trip_miles: Annotated[Float64, TableField(lineage="QueryModelSchema['trip_miles']")]
+    trip_miles: Annotated[Float64, TableField(lineage=QueryModelSchema["trip_miles"])]
 
 
 @bauplan.expectation()

--- a/tests/fixtures/python_3_11/models.py
+++ b/tests/fixtures/python_3_11/models.py
@@ -20,7 +20,7 @@ class LocationSchema(TableSchema):
 @bauplan.model(
     materialization_strategy="NONE",
 )
-@bauplan.python()
+@bauplan.python("3.11")
 def normalize_data(
     data: Annotated[pyarrow.Table, Model("query_model")],
 ) -> Annotated[pyarrow.Table, LocationSchema]:

--- a/tests/fixtures/python_3_12/models.py
+++ b/tests/fixtures/python_3_12/models.py
@@ -20,7 +20,7 @@ class LocationSchema(TableSchema):
 @bauplan.model(
     materialization_strategy="NONE",
 )
-@bauplan.python()
+@bauplan.python("3.12")
 def normalize_data(
     data: Annotated[pyarrow.Table, Model("query_model")],
 ) -> Annotated[pyarrow.Table, LocationSchema]:

--- a/tests/fixtures/python_3_13/models.py
+++ b/tests/fixtures/python_3_13/models.py
@@ -20,7 +20,7 @@ class LocationSchema(TableSchema):
 @bauplan.model(
     materialization_strategy="NONE",
 )
-@bauplan.python()
+@bauplan.python("3.13")
 def normalize_data(
     data: Annotated[pyarrow.Table, Model("query_model")],
 ) -> Annotated[pyarrow.Table, LocationSchema]:


### PR DESCRIPTION
These are some miscellany I found while working on the new parser:

 - `@python()` without a version doesn't make much sense.
 - Quoting a whole annotation as a forward expr is redundant, since we treat annotations as lazy (as does python by default from 3.14)