### PR TITLE
chore: Update examples for type contract syntax

### DIFF
--- a/bauplan-sdk-types/pyproject.toml
+++ b/bauplan-sdk-types/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "bauplan-sdk-types"
-version = "0.1.0"
+version = "0.2.0"
 requires-python = ">=3.11"
 readme = "README.md"
 description = "Type and decorator definitions for authoring Bauplan pipelines"

--- a/bauplan-sdk-types/src/bauplan_sdk_types/_table_fields.py
+++ b/bauplan-sdk-types/src/bauplan_sdk_types/_table_fields.py
@@ -121,14 +121,11 @@ class TableField:
         doc: Optional[str] = None,
         title: Optional[str] = None,
         lineage: Optional[FieldType | str] = None,
-        nullable: Optional[bool] = None,
     ):
         """
         `doc`: Documentation for the TableField.
         `title`: A title for the TableField and its documentation.
         `lineage`: A reference to a `TableField` to "inherit" data and metadata from.
-        `nullable`: `True` if the TableField may contain `None` values (`NULL` in SQL);
-                    default value is `None`, default meaning is to accept `None` values.
         """
 
         super().__init__()

--- a/docs/gen_sdk_reference.py
+++ b/docs/gen_sdk_reference.py
@@ -30,17 +30,17 @@ import griffe
 # This means that the display layer is decoupled from the generation.
 
 
-SKIP_MODULES = ['bauplan.extras']
+SKIP_MODULES = ["bauplan.extras"]
 
 # SEO meta descriptions, keyed by module path. Emitted into each generated
 # reference page's front matter. Must be double-quoted in YAML: they contain
 # colons (none contain double quotes, so plain double-quoting is safe).
 SDK_PAGE_DESCRIPTIONS = {
-    'bauplan': 'Reference for the Bauplan Python SDK Client: query tables, run pipelines, import data, and manage branches, commits, tags, and jobs over Apache Iceberg lakehouses.',
-    'bauplan.exceptions': 'Reference for bauplan.exceptions: the Python SDK error hierarchy covering HTTP, merge conflict, not-found, forbidden, and table-plan errors raised by Bauplan.',
-    'bauplan.schema': 'Reference for bauplan.schema types: Branch, Ref, Commit, Tag, Namespace, Table, Job, and DAG classes returned by the Bauplan Python SDK over Iceberg catalogs.',
-    'bauplan.standard_expectations': 'Reference for bauplan.standard_expectations: built-in data quality checks for null, uniqueness, accepted values, mean, and concatenation in Bauplan pipelines.',
-    'bauplan.state': 'Reference for bauplan.state types: RunState, RunExecutionContext, and table-create and import state objects returned by Bauplan Python SDK run and import jobs.',
+    "bauplan": "Reference for the Bauplan Python SDK Client: query tables, run pipelines, import data, and manage branches, commits, tags, and jobs over Apache Iceberg lakehouses.",
+    "bauplan.exceptions": "Reference for bauplan.exceptions: the Python SDK error hierarchy covering HTTP, merge conflict, not-found, forbidden, and table-plan errors raised by Bauplan.",
+    "bauplan.schema": "Reference for bauplan.schema types: Branch, Ref, Commit, Tag, Namespace, Table, Job, and DAG classes returned by the Bauplan Python SDK over Iceberg catalogs.",
+    "bauplan.standard_expectations": "Reference for bauplan.standard_expectations: built-in data quality checks for null, uniqueness, accepted values, mean, and concatenation in Bauplan pipelines.",
+    "bauplan.state": "Reference for bauplan.state types: RunState, RunExecutionContext, and table-create and import state objects returned by Bauplan Python SDK run and import jobs.",
 }
 
 # Single pass over three mutually exclusive patterns:
@@ -50,21 +50,23 @@ SDK_PAGE_DESCRIPTIONS = {
 # Methods register as full_ref ("Client.run"); classes register as name ("InfoState"),
 # so bauplan.InfoState in prose needs the name fallback to match.
 _REF_PATTERN = re.compile(
-    r'(?P<open>`?)'
-    r'(?P<full>'
-    r'bauplan\.(?:\w+\.)+(?P<dotted>\w+)'
-    r'|Client\.(?P<method>\w+)'
-    r'|bauplan\.(?P<short>[A-Z]\w+)'
-    r')'
-    r'(?P<close>`?)'
+    r"(?P<open>`?)"
+    r"(?P<full>"
+    r"bauplan\.(?:\w+\.)+(?P<dotted>\w+)"
+    r"|Client\.(?P<method>\w+)"
+    r"|bauplan\.(?P<short>[A-Z]\w+)"
+    r")"
+    r"(?P<close>`?)"
 )
 
 
-def _walk_module_tree(module: griffe.Module, seen: set[str] | None = None) -> Iterator[griffe.Module]:
+def _walk_module_tree(
+    module: griffe.Module, seen: set[str] | None = None
+) -> Iterator[griffe.Module]:
     """Yield root and all reachable sub-modules, skipping _bpln_proto internals and SKIP_MODULES."""
     if seen is None:
         seen = set()
-    if '._bpln_proto' in module.path:
+    if "._bpln_proto" in module.path:
         return
     page = path_slug(module)
     if page in seen:
@@ -98,7 +100,9 @@ class TypeLinker:
             names = sorted(self._lookup.keys(), key=len, reverse=True)
             if not names:
                 return None
-            self._pattern = re.compile(r'(?<![.\w])(' + '|'.join(re.escape(n) for n in names) + r')\b')
+            self._pattern = re.compile(
+                r"(?<![.\w])(" + "|".join(re.escape(n) for n in names) + r")\b"
+            )
         return self._pattern
 
     def linkify(self, text: str) -> str:
@@ -112,17 +116,17 @@ class TypeLinker:
         def replace_type(match: re.Match) -> str:
             name = match.group(0)
             page_slug, anchor = self._lookup[name]
-            return f'[{name}](/reference/{page_slug}#{anchor})'
+            return f"[{name}](/reference/{page_slug}#{anchor})"
 
         return pattern.sub(replace_type, text)
 
     def format_annotation(self, text: str) -> str:
         """Shorten FQ names, strip Pydantic FieldInfo wrappers, remove typing. prefix, linkify."""
         if not text:
-            return ''
-        text = re.sub(r'bauplan\.\w+\.(\w+)', r'\1', text)
-        text = re.sub(r'Annotated\[(.+?),\s*FieldInfo\([^)]*\)\]', r'\1', text)
-        text = re.sub(r'typing\.', '', text)
+            return ""
+        text = re.sub(r"bauplan\.\w+\.(\w+)", r"\1", text)
+        text = re.sub(r"Annotated\[(.+?),\s*FieldInfo\([^)]*\)\]", r"\1", text)
+        text = re.sub(r"typing\.", "", text)
         return self.linkify(text)
 
     def resolve_bauplan_refs(self, text: str) -> str:
@@ -139,22 +143,26 @@ class TypeLinker:
             return text
 
         def replace(match: re.Match) -> str:
-            open_tick = match.group('open')
-            full_ref = match.group('full')
-            close_tick = match.group('close')
-            name = match.group('dotted') or match.group('method') or match.group('short')
+            open_tick = match.group("open")
+            full_ref = match.group("full")
+            close_tick = match.group("close")
+            name = (
+                match.group("dotted") or match.group("method") or match.group("short")
+            )
             lookup = self._lookup.get(full_ref) or self._lookup.get(name)
             if not lookup:
                 return match.group(0)
             page_slug, anchor = lookup
-            return f'[{open_tick}{full_ref}{close_tick}](/reference/{page_slug}#{anchor})'
+            return (
+                f"[{open_tick}{full_ref}{close_tick}](/reference/{page_slug}#{anchor})"
+            )
 
         def linkify(chunk: str) -> str:
             return _REF_PATTERN.sub(replace, chunk)
 
         # re.split with (...) includes the matched delimiters in the result, so code blocks survive intact
-        parts = re.split(r'(```[\s\S]*?```)', text)
-        return ''.join(p if p.startswith('```') else linkify(p) for p in parts)
+        parts = re.split(r"(```[\s\S]*?```)", text)
+        return "".join(p if p.startswith("```") else linkify(p) for p in parts)
 
     def build_lookup(self, module: griffe.Module) -> None:
         """Walk module tree to build name -> (page, anchor) lookup."""
@@ -166,24 +174,32 @@ class TypeLinker:
                 try:
                     resolved = resolve(member)
                 except Exception:
-                    logging.debug('Could not resolve member %s', member.name)
+                    logging.debug("Could not resolve member %s", member.name)
                     continue
 
                 match resolved.kind:
                     case griffe.Kind.CLASS:
-                        anchor = f'{page}-{member.name.lower()}'
+                        anchor = f"{page}-{member.name.lower()}"
                         self.register(resolved.name, page, anchor)
                         for cls_member in resolved.members.values():
-                            if not cls_member.is_public or cls_member.name.startswith('_'):
+                            if not cls_member.is_public or cls_member.name.startswith(
+                                "_"
+                            ):
                                 continue
                             try:
                                 cls_resolved = resolve(cls_member)
                             except Exception:
-                                logging.debug('Could not resolve class member %s', cls_member.name)
+                                logging.debug(
+                                    "Could not resolve class member %s", cls_member.name
+                                )
                                 continue
                             if cls_resolved.kind == griffe.Kind.FUNCTION:
-                                method_anchor = f'{anchor}-{cls_member.name.lower()}'
-                                self.register(f'{resolved.name}.{cls_member.name}', page, method_anchor)
+                                method_anchor = f"{anchor}-{cls_member.name.lower()}"
+                                self.register(
+                                    f"{resolved.name}.{cls_member.name}",
+                                    page,
+                                    method_anchor,
+                                )
                     case griffe.Kind.FUNCTION:
                         anchor = function_slug(page, member.name)
                         self.register(resolved.name, page, anchor)
@@ -197,7 +213,7 @@ class ParsedDocstring:
     # Callers that don't need the split use write() directly (e.g. module docstrings).
 
     def __init__(self, docstring: griffe.Docstring, linker: TypeLinker) -> None:
-        self.sections = list(docstring.parse('google'))
+        self.sections = list(docstring.parse("google"))
         self._linker = linker
         self._process_bauplan_references()
 
@@ -211,69 +227,93 @@ class ParsedDocstring:
 
                 case griffe.DocstringSectionKind.parameters:
                     for param in section.value:
-                        if hasattr(param, 'description') and param.description:
+                        if hasattr(param, "description") and param.description:
                             param.description = resolve_refs(param.description)
 
-                case griffe.DocstringSectionKind.returns | griffe.DocstringSectionKind.yields:
+                case (
+                    griffe.DocstringSectionKind.returns
+                    | griffe.DocstringSectionKind.yields
+                ):
                     for return_item in section.value:
-                        if hasattr(return_item, 'description') and return_item.description:
-                            return_item.description = resolve_refs(return_item.description)
+                        if (
+                            hasattr(return_item, "description")
+                            and return_item.description
+                        ):
+                            return_item.description = resolve_refs(
+                                return_item.description
+                            )
 
                 case griffe.DocstringSectionKind.raises:
                     for exception in section.value:
-                        if hasattr(exception, 'description') and exception.description:
+                        if hasattr(exception, "description") and exception.description:
                             exception.description = resolve_refs(exception.description)
 
                 case griffe.DocstringSectionKind.examples:
                     for example in section.value:
-                        if hasattr(example, 'description') and example.description:
+                        if hasattr(example, "description") and example.description:
                             example.description = resolve_refs(example.description)
 
                 case _:
-                    if hasattr(section, 'value'):
+                    if hasattr(section, "value"):
                         if isinstance(section.value, str):
                             section.value = resolve_refs(section.value)
-                        elif hasattr(section.value, 'description'):
-                            section.value.description = resolve_refs(section.value.description)
+                        elif hasattr(section.value, "description"):
+                            section.value.description = resolve_refs(
+                                section.value.description
+                            )
 
     def _apply_heading_demotion(self, text: str) -> str:
         # Demote h1-h3 headings in docstring prose to h4 so they don't
         # appear in the Docusaurus TOC (which only indexes h2/h3).
         # Skip code fences — Python comments start with '#' too.
-        parts = re.split(r'(```[\s\S]*?```)', text)
-        return ''.join(
-            re.sub(r'^#{1,3} ', '#### ', part, flags=re.MULTILINE) if i % 2 == 0 else part
+        parts = re.split(r"(```[\s\S]*?```)", text)
+        return "".join(
+            re.sub(r"^#{1,3} ", "#### ", part, flags=re.MULTILINE)
+            if i % 2 == 0
+            else part
             for i, part in enumerate(parts)
         )
 
     def _write_returns(self, output: TextIO, section: griffe.DocstringSection) -> None:
         if section.value:
-            label = 'Yields' if section.kind == griffe.DocstringSectionKind.yields else 'Returns'
-            output.write(f'{label}:\n')
+            label = (
+                "Yields"
+                if section.kind == griffe.DocstringSectionKind.yields
+                else "Returns"
+            )
+            output.write(f"{label}:\n")
             for item in section.value:
-                description = item.description or str(item.annotation or '')
-                output.write(f'    {description}\n')
-            output.write('\n')
+                description = item.description or str(item.annotation or "")
+                output.write(f"    {description}\n")
+            output.write("\n")
 
     def write_returns_component(self, output: TextIO) -> None:
         """Write returns/yields as a <PyReturns> component instead of prose."""
         for section in self.sections:
-            if section.kind in (griffe.DocstringSectionKind.returns, griffe.DocstringSectionKind.yields):
+            if section.kind in (
+                griffe.DocstringSectionKind.returns,
+                griffe.DocstringSectionKind.yields,
+            ):
                 if section.value:
                     for item in section.value:
-                        description = item.description or str(item.annotation or '')
+                        description = item.description or str(item.annotation or "")
                         if description:
                             output.write(
                                 f'<PyReturns description="{escape_xml_attribute(description)}" />\n\n'
                             )
-            elif section.kind == griffe.DocstringSectionKind.text and self._is_returns_text(section.value):
+            elif (
+                section.kind == griffe.DocstringSectionKind.text
+                and self._is_returns_text(section.value)
+            ):
                 # griffe emits some Returns sections as plain text — extract the description
                 text = section.value.strip()
                 # Strip "Returns:\n    " prefix
-                m = re.match(r'(?:Returns|Yields):\s*\n\s+(.+)', text, re.DOTALL)
+                m = re.match(r"(?:Returns|Yields):\s*\n\s+(.+)", text, re.DOTALL)
                 if m:
                     description = m.group(1).strip()
-                    output.write(f'<PyReturns description="{escape_xml_attribute(description)}" />\n\n')
+                    output.write(
+                        f'<PyReturns description="{escape_xml_attribute(description)}" />\n\n'
+                    )
 
     def write(self, output: TextIO) -> None:
         """Write text and returns sections. Raises are deferred to write_raises()."""
@@ -281,9 +321,12 @@ class ParsedDocstring:
             match section.kind:
                 case griffe.DocstringSectionKind.text:
                     output.write(self._apply_heading_demotion(section.value))
-                    output.write('\n\n')
+                    output.write("\n\n")
 
-                case griffe.DocstringSectionKind.returns | griffe.DocstringSectionKind.yields:
+                case (
+                    griffe.DocstringSectionKind.returns
+                    | griffe.DocstringSectionKind.yields
+                ):
                     # Render structured returns/yields as plain text for consistency,
                     # since griffe only parses some Returns sections as structured.
                     self._write_returns(output, section)
@@ -292,20 +335,23 @@ class ParsedDocstring:
         """Write the first paragraph of the first text section."""
         for section in self.sections:
             if section.kind == griffe.DocstringSectionKind.text:
-                first_para = section.value.split('\n\n')[0].strip()
+                first_para = section.value.split("\n\n")[0].strip()
                 if first_para:
-                    output.write(first_para + '\n\n')
+                    output.write(first_para + "\n\n")
                 return
 
     # griffe sometimes emits "Returns:\n    ..." as a plain text section rather than a
     # structured returns section (common with .pyi stubs). Detect and route correctly.
-    _RETURNS_HEADER = re.compile(r'^(Returns|Yields):', re.IGNORECASE)
+    _RETURNS_HEADER = re.compile(r"^(Returns|Yields):", re.IGNORECASE)
 
     def _is_returns_text(self, text: str) -> bool:
         return bool(self._RETURNS_HEADER.match(text.strip()))
 
     def _first_text_section(self) -> griffe.DocstringSection | None:
-        return next((s for s in self.sections if s.kind == griffe.DocstringSectionKind.text), None)
+        return next(
+            (s for s in self.sections if s.kind == griffe.DocstringSectionKind.text),
+            None,
+        )
 
     def _after_first_paragraph(self, section_value: str) -> str:
         """Return everything after the first paragraph break, or '' if there is none.
@@ -313,16 +359,16 @@ class ParsedDocstring:
         When there is no \\n\\n the entire section IS the first paragraph (already written by
         write_preamble), so returning '' is correct — no content is lost.
         """
-        _, sep, rest = section_value.partition('\n\n')
-        return rest.lstrip('\n') if sep else ''
+        _, sep, rest = section_value.partition("\n\n")
+        return rest.lstrip("\n") if sep else ""
 
-    _UPON_FAILURE_RE = re.compile(r'Upon failure,?\s+raises\b.*', re.IGNORECASE)
+    _UPON_FAILURE_RE = re.compile(r"Upon failure,?\s+raises\b.*", re.IGNORECASE)
 
     def _filter_upon_failure(self, text: str) -> str:
         """Remove 'Upon failure, raises...' sentences from prose."""
-        paragraphs = re.split(r'\n\n+', text)
+        paragraphs = re.split(r"\n\n+", text)
         kept = [p for p in paragraphs if not self._UPON_FAILURE_RE.search(p)]
-        return '\n\n'.join(kept)
+        return "\n\n".join(kept)
 
     def write_description(self, output: TextIO) -> None:
         """Write prose (non-code-block) parts of text sections, skipping the first paragraph."""
@@ -330,41 +376,58 @@ class ParsedDocstring:
         for section in self.sections:
             if section.kind != griffe.DocstringSectionKind.text:
                 continue
-            text = self._after_first_paragraph(section.value) if section is first else section.value
+            text = (
+                self._after_first_paragraph(section.value)
+                if section is first
+                else section.value
+            )
             if not text.strip() or self._is_returns_text(text):
                 continue
-            parts = re.split(r'(```[\s\S]*?```)', text)
-            prose = ''.join(part for i, part in enumerate(parts) if i % 2 == 0).strip()
+            parts = re.split(r"(```[\s\S]*?```)", text)
+            prose = "".join(part for i, part in enumerate(parts) if i % 2 == 0).strip()
             prose = self._filter_upon_failure(prose).strip()
             if prose:
                 prose = self._apply_heading_demotion(prose)
                 # strip standalone Example/Examples headings — write_examples adds its own
-                prose = re.sub(r'(?m)^####\s+Examples?\s*$\n?', '', prose).strip()
+                prose = re.sub(r"(?m)^####\s+Examples?\s*$\n?", "", prose).strip()
             if prose:
                 output.write(prose)
-                output.write('\n\n')
+                output.write("\n\n")
 
     def write_body(self, output: TextIO) -> None:
         """Write the full body (everything after the first paragraph), preserving prose+code order."""
         first = self._first_text_section()
         for section in self.sections:
             if section.kind == griffe.DocstringSectionKind.text:
-                text = self._after_first_paragraph(section.value) if section is first else section.value
+                text = (
+                    self._after_first_paragraph(section.value)
+                    if section is first
+                    else section.value
+                )
                 if not text.strip() or self._is_returns_text(text):
                     continue
                 output.write(self._apply_heading_demotion(text.strip()))
-                output.write('\n\n')
-            elif section.kind in (griffe.DocstringSectionKind.returns, griffe.DocstringSectionKind.yields):
+                output.write("\n\n")
+            elif section.kind in (
+                griffe.DocstringSectionKind.returns,
+                griffe.DocstringSectionKind.yields,
+            ):
                 self._write_returns(output, section)
 
     def write_returns(self, output: TextIO) -> None:
         """Write returns/yields — both structured sections and returns-like text sections."""
         for section in self.sections:
-            if section.kind in (griffe.DocstringSectionKind.returns, griffe.DocstringSectionKind.yields):
+            if section.kind in (
+                griffe.DocstringSectionKind.returns,
+                griffe.DocstringSectionKind.yields,
+            ):
                 self._write_returns(output, section)
-            elif section.kind == griffe.DocstringSectionKind.text and self._is_returns_text(section.value):
+            elif (
+                section.kind == griffe.DocstringSectionKind.text
+                and self._is_returns_text(section.value)
+            ):
                 output.write(section.value.strip())
-                output.write('\n\n')
+                output.write("\n\n")
 
     def write_examples(self, output: TextIO) -> None:
         """Write code block examples from text sections, skipping the first paragraph."""
@@ -373,20 +436,24 @@ class ParsedDocstring:
         for section in self.sections:
             if section.kind != griffe.DocstringSectionKind.text:
                 continue
-            text = self._after_first_paragraph(section.value) if section is first else section.value
+            text = (
+                self._after_first_paragraph(section.value)
+                if section is first
+                else section.value
+            )
             if not text.strip() or self._is_returns_text(text):
                 continue
-            parts = re.split(r'(```[\s\S]*?```)', text)
+            parts = re.split(r"(```[\s\S]*?```)", text)
             for i, part in enumerate(parts):
                 if i % 2 == 1:
                     blocks.append(part)
 
         if blocks:
-            label = 'Examples' if len(blocks) > 1 else 'Example'
-            output.write(f'#### {label}\n\n')
+            label = "Examples" if len(blocks) > 1 else "Example"
+            output.write(f"#### {label}\n\n")
             for block in blocks:
                 output.write(block)
-                output.write('\n\n')
+                output.write("\n\n")
 
     def write_raises(self, output: TextIO) -> None:
         """Write Raises sections. Call after parameters."""
@@ -394,16 +461,20 @@ class ParsedDocstring:
             match section.kind:
                 case griffe.DocstringSectionKind.raises:
                     if section.value:
-                        output.write('<PyParameters title="Raises" defaultOpen={false}>\n')
+                        output.write(
+                            '<PyParameters title="Raises" defaultOpen={false}>\n'
+                        )
                         for i, item in enumerate(section.value):
-                            raw_name = str(item.annotation or '').strip('`')
-                            name = html.escape(self._linker.resolve_bauplan_refs(raw_name))
-                            description = html.escape(item.description or '')
+                            raw_name = str(item.annotation or "").strip("`")
+                            name = html.escape(
+                                self._linker.resolve_bauplan_refs(raw_name)
+                            )
+                            description = html.escape(item.description or "")
                             is_odd = i % 2 == 1
                             output.write(
                                 f'<PyParameter name="{name}" annotation="" default="" description="{description}" showBadge={{false}} isOdd={{{str(is_odd).lower()}}}/>\n'
                             )
-                        output.write('</PyParameters>\n\n')
+                        output.write("</PyParameters>\n\n")
 
     def get_parameter_description(self, name: str) -> str | None:
         for section in self.sections:
@@ -415,39 +486,41 @@ class ParsedDocstring:
 
 
 def main() -> None:
-    output_dir = Path(__file__).parent / 'pages' / 'reference'
+    output_dir = Path(__file__).parent / "pages" / "reference"
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    bauplan = griffe.load('bauplan')
+    bauplan = griffe.load("bauplan")
 
     assert isinstance(bauplan, griffe.Module)
     linker = TypeLinker()
     linker.build_lookup(bauplan)
     module_names = process_module(output_dir, bauplan, linker)
 
-    print(f'Processed {len(module_names)} modules')
-    with open(output_dir / '_sidebar.json', 'w') as f:
-        pages = sorted([f'reference/{name}' for name in module_names])
+    print(f"Processed {len(module_names)} modules")
+    with open(output_dir / "_sidebar.json", "w") as f:
+        pages = sorted([f"reference/{name}" for name in module_names])
         json.dump(pages, f)
 
 
 def _member_sort_key(m: griffe.Object) -> tuple[int, str]:
-    return (0 if m.name == 'Client' else 1, m.name)
+    return (0 if m.name == "Client" else 1, m.name)
 
 
-def process_module(output_dir: Path, module: griffe.Module, linker: TypeLinker) -> list[str]:
+def process_module(
+    output_dir: Path, module: griffe.Module, linker: TypeLinker
+) -> list[str]:
     names = []
     for mod in _walk_module_tree(module):
         name = path_slug(mod)
         names.append(name)
 
-        with open(output_dir / f'{name}.mdx', 'w') as f:
-            f.write('---\n')
+        with open(output_dir / f"{name}.mdx", "w") as f:
+            f.write("---\n")
             f.write(f'title: "{mod.path}"\n')
             description = SDK_PAGE_DESCRIPTIONS.get(mod.path)
             if description:
                 f.write(f'description: "{description}"\n')
-            f.write('---\n\n')
+            f.write("---\n\n")
 
             # Build a table of contents.
             toc = []
@@ -455,43 +528,57 @@ def process_module(output_dir: Path, module: griffe.Module, linker: TypeLinker) 
             if mod.docstring:
                 ParsedDocstring(mod.docstring, linker).write(f)
 
-            for member in sorted(mod.members.values(), key=_member_sort_key): # ty:ignore
+            for member in sorted(mod.members.values(), key=_member_sort_key):  # ty:ignore
                 if not member.is_public:
                     continue
 
                 match member.kind:
                     case griffe.Kind.CLASS:
-                        with wrap(f, 'PyModuleMember', member.name):
+                        with wrap(f, "PyModuleMember", member.name):
                             process_class(f, toc, member, linker, page_slug=name)
                     case griffe.Kind.FUNCTION:
-                        with wrap(f, 'PyModuleMember', member.name):
-                            process_function(f, toc, 2, member, linker, slug=function_slug(name, member.name))
+                        with wrap(f, "PyModuleMember", member.name):
+                            process_function(
+                                f,
+                                toc,
+                                2,
+                                member,
+                                linker,
+                                slug=function_slug(name, member.name),
+                            )
                     case griffe.Kind.MODULE:
                         pass  # handled by _walk_module_tree
                     case _:
-                        print(f'WARNING: skipping {member.path}: {member.kind}')
+                        print(f"WARNING: skipping {member.path}: {member.kind}")
 
             toc_json = json.dumps(json.dumps(toc))
-            f.write(f'export const toc = JSON.parse({toc_json});\n')
+            f.write(f"export const toc = JSON.parse({toc_json});\n")
 
     return names
 
 
 def process_parameters(
-    output: TextIO, parameters: griffe.Parameters, docstring: ParsedDocstring | None, linker: TypeLinker
+    output: TextIO,
+    parameters: griffe.Parameters,
+    docstring: ParsedDocstring | None,
+    linker: TypeLinker,
 ) -> None:
-    if not parameters or (len(parameters) == 1 and parameters[0].name == 'self'):
+    if not parameters or (len(parameters) == 1 and parameters[0].name == "self"):
         return
-    with wrap(output, 'PyParameters'):
+    with wrap(output, "PyParameters"):
         for parameter in parameters:
-            if parameter.name in ['self', 'cls', 'args', 'kwargs']:
+            if parameter.name in ["self", "cls", "args", "kwargs"]:
                 continue
 
-            annotation = linker.format_annotation(str(parameter.annotation or ''))
+            annotation = linker.format_annotation(str(parameter.annotation or ""))
             annotation = escape_xml_attribute(annotation)
-            default = escape_xml_attribute(str(parameter.default or ''))
-            description = docstring.get_parameter_description(parameter.name) if docstring else None
-            description = escape_xml_attribute(description or '')
+            default = escape_xml_attribute(str(parameter.default or ""))
+            description = (
+                docstring.get_parameter_description(parameter.name)
+                if docstring
+                else None
+            )
+            description = escape_xml_attribute(description or "")
             output.write(
                 f'<PyParameter name="{parameter.name}" annotation="{annotation}" default="{default}" description="{description}"/>\n'
             )
@@ -500,23 +587,25 @@ def process_parameters(
 def get_base_class_link(base_class: griffe.Class) -> str:
     """Generate a link to a base class documentation."""
     # Get the module path from the parent module
-    module_path = base_class.parent.path if base_class.parent else ''
-    base_module_path = module_path.replace('.', '-')
+    module_path = base_class.parent.path if base_class.parent else ""
+    base_module_path = module_path.replace(".", "-")
 
     # Create the anchor (module_path + class_name in lowercase)
-    anchor = f'{base_module_path}-{base_class.name.lower()}'
+    anchor = f"{base_module_path}-{base_class.name.lower()}"
 
-    return f'/reference/{base_module_path}#{anchor}'
+    return f"/reference/{base_module_path}#{anchor}"
 
 
-def _get_signature_params(cls: griffe.Class, linker: TypeLinker) -> list[tuple[str, str, str]] | None:
+def _get_signature_params(
+    cls: griffe.Class, linker: TypeLinker
+) -> list[tuple[str, str, str]] | None:
     """
     Extract structured (name, annotation, default) params for a class.
 
     Returns None if the signature should be skipped (empty or unavailable).
     Checks __init__ first, then __new__ (used by PyO3/Rust extension classes).
     """
-    constructor = cls.members.get('__init__') or cls.members.get('__new__')
+    constructor = cls.members.get("__init__") or cls.members.get("__new__")
     if constructor is None:
         return None
 
@@ -527,19 +616,21 @@ def _get_signature_params(cls: griffe.Class, linker: TypeLinker) -> list[tuple[s
 
     params = []
     for p in resolved_constructor.parameters:
-        if p.name in ('self', 'cls', 'args', 'kwargs'):
+        if p.name in ("self", "cls", "args", "kwargs"):
             continue
-        if p.name == '*':
-            params.append(('*', '', ''))
+        if p.name == "*":
+            params.append(("*", "", ""))
             continue
-        ann = linker.format_annotation(str(p.annotation) if p.annotation else '')
-        default = str(p.default) if p.default else ''
+        ann = linker.format_annotation(str(p.annotation) if p.annotation else "")
+        default = str(p.default) if p.default else ""
         params.append((p.name, ann, default))
 
     return params or None
 
 
-def format_and_write_signature(cls: griffe.Class, output: TextIO, linker: TypeLinker) -> None:
+def format_and_write_signature(
+    cls: griffe.Class, output: TextIO, linker: TypeLinker
+) -> None:
     """
     Format and write a class signature as a <PySignature> JSX component.
 
@@ -554,13 +645,13 @@ def format_and_write_signature(cls: griffe.Class, output: TextIO, linker: TypeLi
 
     output.write(f'<PySignature name="{cls.path}">\n')
     for name, ann, default in params:
-        if name == '*':
+        if name == "*":
             output.write('<PySignatureParam name="*" separator=""/>\n')
             continue
-        ann_attr = f' annotation="{escape_xml_attribute(ann)}"' if ann else ''
-        def_attr = f' defaultValue="{escape_xml_attribute(default)}"' if default else ''
+        ann_attr = f' annotation="{escape_xml_attribute(ann)}"' if ann else ""
+        def_attr = f' defaultValue="{escape_xml_attribute(default)}"' if default else ""
         output.write(f'<PySignatureParam name="{name}"{ann_attr}{def_attr}/>\n')
-    output.write('</PySignature>\n\n')
+    output.write("</PySignature>\n\n")
 
 
 def _get_class_bases(cls: griffe.Class, linker: TypeLinker) -> list[dict[str, str]]:
@@ -569,7 +660,7 @@ def _get_class_bases(cls: griffe.Class, linker: TypeLinker) -> list[dict[str, st
     for base_name in cls.bases:
         formatted = linker.format_annotation(str(base_name))
 
-        link = ''
+        link = ""
         try:
             base_obj = cls.modules_collection[str(base_name)]
             if isinstance(base_obj, griffe.Class) and base_obj.is_public:
@@ -577,23 +668,29 @@ def _get_class_bases(cls: griffe.Class, linker: TypeLinker) -> list[dict[str, st
         except (KeyError, TypeError):
             pass
 
-        bases_list.append({'name': formatted, 'link': link})
+        bases_list.append({"name": formatted, "link": link})
 
     return bases_list
 
 
 def process_class(
-    output: TextIO, toc: list[dict], cls: griffe.Class, linker: TypeLinker, page_slug: str | None = None
+    output: TextIO,
+    toc: list[dict],
+    cls: griffe.Class,
+    linker: TypeLinker,
+    page_slug: str | None = None,
 ) -> None:
-    slug = f'{page_slug}-{cls.name.lower()}' if page_slug else path_slug(cls)
-    toc.append({'value': cls.name, 'id': slug, 'level': 2})
+    slug = f"{page_slug}-{cls.name.lower()}" if page_slug else path_slug(cls)
+    toc.append({"value": cls.name, "id": slug, "level": 2})
 
-    is_enum = any('Enum' in str(b) for b in cls.bases)
+    is_enum = any("Enum" in str(b) for b in cls.bases)
     is_sealed = _get_signature_params(cls, linker) is None and not is_enum
-    sealed_attr = ' sealed={true}' if is_sealed else ''
+    sealed_attr = " sealed={true}" if is_sealed else ""
     output.write(f'<PyClass id="{slug}" name="{cls.name}"{sealed_attr}>\n\n')
 
-    parsed = ParsedDocstring(cls.docstring, linker) if cls.docstring is not None else None
+    parsed = (
+        ParsedDocstring(cls.docstring, linker) if cls.docstring is not None else None
+    )
     if parsed:
         parsed.write_preamble(output)
 
@@ -602,18 +699,18 @@ def process_class(
         enum_members = [
             (name, member)
             for name, member in cls.members.items()
-            if not name.startswith('_') and member.kind == griffe.Kind.ATTRIBUTE
+            if not name.startswith("_") and member.kind == griffe.Kind.ATTRIBUTE
         ]
         if enum_members:
-            bases_str = ', '.join(str(b).rsplit('.', 1)[-1] for b in cls.bases)
-            output.write(f'```python notest\nclass {cls.name}({bases_str}):\n')
+            bases_str = ", ".join(str(b).rsplit(".", 1)[-1] for b in cls.bases)
+            output.write(f"```python notest\nclass {cls.name}({bases_str}):\n")
             for name, member in enum_members:
                 # Extract value from repr like "<EntryType.TABLE: 'TABLE'>" -> 'TABLE'
                 raw = str(member.value)
-                m = re.search(r':\s*(.+?)>$', raw)
+                m = re.search(r":\s*(.+?)>$", raw)
                 val = m.group(1).strip() if m else repr(raw)
-                output.write(f'    {name} = {val}\n')
-            output.write('```\n\n')
+                output.write(f"    {name} = {val}\n")
+            output.write("```\n\n")
     else:
         format_and_write_signature(cls, output, linker)
 
@@ -621,7 +718,7 @@ def process_class(
     attributes = []
     functions = []
     for member in cls.members.values():
-        if not member.is_public or member.name.startswith('_'):
+        if not member.is_public or member.name.startswith("_"):
             continue
         match member.kind:
             case griffe.Kind.ATTRIBUTE:
@@ -632,13 +729,15 @@ def process_class(
     # show constructor parameters only when there are no attribute members
     # (attributes and constructor params are usually the same fields — avoid duplication)
     if not attributes:
-        constructor = cls.members.get('__init__') or cls.members.get('__new__')
+        constructor = cls.members.get("__init__") or cls.members.get("__new__")
         if constructor:
             try:
                 resolved_constructor = resolve(constructor)
-                process_parameters(output, resolved_constructor.parameters, parsed, linker)
+                process_parameters(
+                    output, resolved_constructor.parameters, parsed, linker
+                )
             except Exception:
-                logging.debug('Could not resolve constructor for %s', cls.name)
+                logging.debug("Could not resolve constructor for %s", cls.name)
 
     # raises, then full body (prose + code blocks interleaved — classes often have rich sectioned docs)
     if parsed:
@@ -648,25 +747,31 @@ def process_class(
     # bases
     bases_list = _get_class_bases(cls, linker)
     if bases_list:
-        output.write(f'<PyClassBase bases={{{json.dumps(bases_list)}}}/>\n')
+        output.write(f"<PyClassBase bases={{{json.dumps(bases_list)}}}/>\n")
 
     if attributes:
-        output.write('<PyAttributesList>\n\n')
+        output.write("<PyAttributesList>\n\n")
         for i, attr in enumerate(attributes):
             process_class_attribute(output, attr, linker, i % 2 == 1)
-        output.write('\n</PyAttributesList>\n\n')
+        output.write("\n</PyAttributesList>\n\n")
 
     for member in functions:
-        with wrap(output, 'PyClassMember', member.name):
-            process_function(output, toc, 3, member, linker, slug=f'{slug}-{member.name.lower()}')
+        with wrap(output, "PyClassMember", member.name):
+            process_function(
+                output, toc, 3, member, linker, slug=f"{slug}-{member.name.lower()}"
+            )
 
-    output.write('</PyClass>\n\n')
+    output.write("</PyClass>\n\n")
 
 
-def process_class_attribute(output: TextIO, attr: griffe.Attribute, linker: TypeLinker, is_odd: bool) -> None:
+def process_class_attribute(
+    output: TextIO, attr: griffe.Attribute, linker: TypeLinker, is_odd: bool
+) -> None:
     name = attr.name
-    annotation = linker.format_annotation(str(attr.annotation)) if attr.annotation else ''
-    description = attr.docstring.value if attr.docstring else ''
+    annotation = (
+        linker.format_annotation(str(attr.annotation)) if attr.annotation else ""
+    )
+    description = attr.docstring.value if attr.docstring else ""
     if description:
         description = linker.resolve_bauplan_refs(description)
     output.write(
@@ -675,7 +780,7 @@ def process_class_attribute(output: TextIO, attr: griffe.Attribute, linker: Type
 
 
 def _strip_md_links(text: str) -> str:
-    return re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', text)
+    return re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
 
 
 def format_function_signature(fn: griffe.Function, linker: TypeLinker) -> str:
@@ -684,7 +789,7 @@ def format_function_signature(fn: griffe.Function, linker: TypeLinker) -> str:
     prev_kind: griffe.ParameterKind | None = None
 
     for p in fn.parameters:
-        if p.name in ('self', 'cls'):
+        if p.name in ("self", "cls"):
             continue
 
         kind = p.kind
@@ -695,51 +800,55 @@ def format_function_signature(fn: griffe.Function, linker: TypeLinker) -> str:
             griffe.ParameterKind.keyword_only,
             griffe.ParameterKind.var_positional,
         ):
-            parts.append('*')
+            parts.append("*")
 
         if kind == griffe.ParameterKind.var_positional:
-            prefix = '*'
+            prefix = "*"
         elif kind == griffe.ParameterKind.var_keyword:
-            prefix = '**'
+            prefix = "**"
         else:
-            prefix = ''
+            prefix = ""
 
         param_str = prefix + p.name
         if p.annotation:
             ann = _strip_md_links(linker.format_annotation(str(p.annotation)))
-            param_str += f': {ann}'
+            param_str += f": {ann}"
         if p.default:
-            param_str += f' = {p.default}'
+            param_str += f" = {p.default}"
 
         parts.append(param_str)
         prev_kind = kind
 
-    ret = ''
+    ret = ""
     if fn.returns:
         ret_str = _strip_md_links(linker.format_annotation(str(fn.returns)))
-        ret = f' -> {ret_str}'
+        ret = f" -> {ret_str}"
 
-    single_line = f'def {fn.name}({", ".join(parts)}){ret}: ...'
+    single_line = f"def {fn.name}({', '.join(parts)}){ret}: ..."
     if len(single_line) <= 88:
         return single_line
 
     # Black-style multi-line: one param per line, trailing comma, closing paren alone
-    indented = ',\n    '.join(parts)
-    return f'def {fn.name}(\n    {indented},\n){ret}: ...'
+    indented = ",\n    ".join(parts)
+    return f"def {fn.name}(\n    {indented},\n){ret}: ..."
 
 
-def write_function_signature(output: TextIO, fn: griffe.Function, linker: TypeLinker) -> None:
+def write_function_signature(
+    output: TextIO, fn: griffe.Function, linker: TypeLinker
+) -> None:
     """Write a function signature as a <PySignature> component (no copy button, syntax-highlighted)."""
     returns_ann = (
-        escape_xml_attribute(_strip_md_links(linker.format_annotation(str(fn.returns)))) if fn.returns else ''
+        escape_xml_attribute(_strip_md_links(linker.format_annotation(str(fn.returns))))
+        if fn.returns
+        else ""
     )
-    returns_attr = f' returns="{returns_ann}"' if returns_ann else ''
+    returns_attr = f' returns="{returns_ann}"' if returns_ann else ""
 
     output.write(f'<PySignature name="def {fn.name}"{returns_attr}>\n')
 
     prev_kind: griffe.ParameterKind | None = None
     for p in fn.parameters:
-        if p.name in ('self', 'cls'):
+        if p.name in ("self", "cls"):
             continue
 
         kind = p.kind
@@ -751,21 +860,23 @@ def write_function_signature(output: TextIO, fn: griffe.Function, linker: TypeLi
             output.write('<PySignatureParam name="*" separator=""/>\n')
 
         if kind == griffe.ParameterKind.var_positional:
-            prefix = '*'
+            prefix = "*"
         elif kind == griffe.ParameterKind.var_keyword:
-            prefix = '**'
+            prefix = "**"
         else:
-            prefix = ''
+            prefix = ""
 
         name = prefix + p.name
-        ann = escape_xml_attribute(_strip_md_links(linker.format_annotation(str(p.annotation or ''))))
-        default = escape_xml_attribute(str(p.default or ''))
-        ann_attr = f' annotation="{ann}"' if ann else ''
-        def_attr = f' defaultValue="{default}"' if default else ''
+        ann = escape_xml_attribute(
+            _strip_md_links(linker.format_annotation(str(p.annotation or "")))
+        )
+        default = escape_xml_attribute(str(p.default or ""))
+        ann_attr = f' annotation="{ann}"' if ann else ""
+        def_attr = f' defaultValue="{default}"' if default else ""
         output.write(f'<PySignatureParam name="{name}"{ann_attr}{def_attr}/>\n')
         prev_kind = kind
 
-    output.write('</PySignature>\n\n')
+    output.write("</PySignature>\n\n")
 
 
 def process_function(
@@ -777,7 +888,7 @@ def process_function(
     slug: str | None = None,
 ) -> None:
     slug = slug or path_slug(fn)
-    toc.append({'value': f'{fn.name}()', 'id': slug, 'level': toc_level})
+    toc.append({"value": f"{fn.name}()", "id": slug, "level": toc_level})
 
     output.write(f'<PyFunction id="{slug}" name="{fn.name}">\n')
 
@@ -797,36 +908,42 @@ def process_function(
         docstring.write_description(output)
         docstring.write_examples(output)
 
-    output.write('</PyFunction>\n\n')
+    output.write("</PyFunction>\n\n")
 
 
-def process_type_alias(output: TextIO, toc: list[dict], alias: griffe.TypeAlias) -> None:
+def process_type_alias(
+    output: TextIO, toc: list[dict], alias: griffe.TypeAlias
+) -> None:
     slug = path_slug(alias)
-    toc.append({'value': alias.name, 'id': slug, 'level': 2})
+    toc.append({"value": alias.name, "id": slug, "level": 2})
 
-    annotation = html.escape(str(alias.value or ''))
-    output.write(f'<PyTypeAlias id="{slug}" name="{alias.name}" annotation="{annotation}"/>\n')
+    annotation = html.escape(str(alias.value or ""))
+    output.write(
+        f'<PyTypeAlias id="{slug}" name="{alias.name}" annotation="{annotation}"/>\n'
+    )
 
 
 @contextmanager
-def wrap(output: TextIO, component_name: str, comment: str | None = None) -> Iterator[None]:
-    comment = f' {jsx_comment(comment)}' if comment else ''
+def wrap(
+    output: TextIO, component_name: str, comment: str | None = None
+) -> Iterator[None]:
+    comment = f" {jsx_comment(comment)}" if comment else ""
 
-    output.write(f'<{component_name}>{comment}\n\n')
+    output.write(f"<{component_name}>{comment}\n\n")
     yield
-    output.write(f'</{component_name}>{comment}\n\n')
+    output.write(f"</{component_name}>{comment}\n\n")
 
 
 def jsx_comment(text: str) -> str:
-    return '{/* ' + html.escape(text) + ' */}'
+    return "{/* " + html.escape(text) + " */}"
 
 
 def function_slug(page_slug: str, function_name: str) -> str:
-    return f'{page_slug}-{function_name.lower()}-function'
+    return f"{page_slug}-{function_name.lower()}-function"
 
 
 def path_slug(obj: griffe.Object) -> str:
-    return re.sub(r'[^a-z0-9-]', '-', obj.path.lower())
+    return re.sub(r"[^a-z0-9-]", "-", obj.path.lower())
 
 
 def resolve[T](obj: griffe.Alias | griffe.Object) -> T:
@@ -838,15 +955,15 @@ def resolve[T](obj: griffe.Alias | griffe.Object) -> T:
 def escape_xml_attribute(value: str) -> str:
     """Escape special characters for XML/JSX attributes."""
     if not value:
-        return ''
+        return ""
     return (
-        value.replace('&', '&amp;')
-        .replace('<', '&lt;')
-        .replace('>', '&gt;')
-        .replace('"', '&quot;')
-        .replace("'", '&#39;')
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#39;")
     )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/examples/learn/01-pipeline-to-dashboard/app/viz_app.py
+++ b/examples/learn/01-pipeline-to-dashboard/app/viz_app.py
@@ -20,7 +20,11 @@ import polars as pl
 
 
 @st.cache_data
-def query_as_dataframe(_client: bauplan.Client, sql: str, branch: str) -> pa.Table | None:
+def query_as_dataframe(
+    _client: bauplan.Client,
+    sql: str,
+    branch: str,
+) -> pa.Table | None:
     """
     Runs a query with bauplan and returns the result as an Arrow dataframe.
     """
@@ -116,20 +120,20 @@ def main():
     )
 
     client = bauplan.Client()
-    
+
     # Make sure the branch exists before querying.
     assert client.has_branch(current_branch), (
         f"Branch '{current_branch}' does not exist. Please check the branch name and try again."
     )
-   
+
     # Make sure the table exists before querying.
-    assert client.has_table(
-        table_name, ref=current_branch
-    ), f"Table '{table_name}' does not exist on "
-       f"branch '{current_branch}'. Please check "
-       f"the branch name and make sure to run the "
-       f"pipeline first."
-   
+    assert client.has_table(table_name, ref=current_branch), (
+        f"Table '{table_name}' does not exist on "
+        f"branch '{current_branch}'. Please check "
+        f"the branch name and make sure to run the "
+        f"pipeline first."
+    )
+
     table = client.get_table(table_name, ref=current_branch)
     num_records = table.records
     print(f"Table '{table_name}' has {num_records} records.")
@@ -142,7 +146,7 @@ def main():
     )
     df = query_as_dataframe(_client=client, sql=sql, branch=current_branch)
     print("Query executed, got result. Converting to Polars DataFrame...")
-    
+
     # Convert to Polars DataFrame for easier
     # manipulation and plotting. This is zero-copy
     # and very fast.

--- a/examples/learn/01-pipeline-to-dashboard/pipeline/models.py
+++ b/examples/learn/01-pipeline-to-dashboard/pipeline/models.py
@@ -50,22 +50,22 @@ class TripsAndZonesSchema(TableSchema):
 
     pickup_datetime: Annotated[
         TimestampMicroUTC,
-        TableField(lineage=TripColumns['pickup_datetime']),
+        TableField(lineage=TripColumns["pickup_datetime"]),
     ]
     dropoff_datetime: Annotated[
         TimestampMicroUTC,
-        TableField(lineage=TripColumns['dropoff_datetime']),
+        TableField(lineage=TripColumns["dropoff_datetime"]),
     ]
-    PULocationID: Annotated[Int64, TableField(lineage=TripColumns['PULocationID'])]
-    DOLocationID: Annotated[Int64, TableField(lineage=TripColumns['DOLocationID'])]
-    trip_miles: Annotated[Float64, TableField(lineage=TripColumns['trip_miles'])]
-    trip_time: Annotated[Int64, TableField(lineage=TripColumns['trip_time'])]
+    PULocationID: Annotated[Int64, TableField(lineage=TripColumns["PULocationID"])]
+    DOLocationID: Annotated[Int64, TableField(lineage=TripColumns["DOLocationID"])]
+    trip_miles: Annotated[Float64, TableField(lineage=TripColumns["trip_miles"])]
+    trip_time: Annotated[Int64, TableField(lineage=TripColumns["trip_time"])]
     base_passenger_fare: Annotated[
-        Float64, TableField(lineage=TripColumns['base_passenger_fare'])
+        Float64, TableField(lineage=TripColumns["base_passenger_fare"])
     ]
-    tolls: Annotated[Float64, TableField(lineage=TripColumns['tolls'])]
-    sales_tax: Annotated[Float64, TableField(lineage=TripColumns['sales_tax'])]
-    tips: Annotated[Float64, TableField(lineage=TripColumns['tips'])]
+    tolls: Annotated[Float64, TableField(lineage=TripColumns["tolls"])]
+    sales_tax: Annotated[Float64, TableField(lineage=TripColumns["sales_tax"])]
+    tips: Annotated[Float64, TableField(lineage=TripColumns["tips"])]
     Borough: Annotated[String, TableField(lineage="taxi_zones['Borough']")]
     Zone: Annotated[String, TableField(lineage="taxi_zones['Zone']")]
     service_zone: Annotated[String, TableField(lineage="taxi_zones['service_zone']")]
@@ -75,7 +75,6 @@ class TripsAndZonesSchema(TableSchema):
 # transformation with many (>= 1) input tables and an output table.
 # Arrow tables are the standard structure for input tables and the output table.
 @bauplan.model()
-
 # The `python` decorator allows you to specify a Python version and any pip packages that
 # should be installed when executing this function. Each function is executed in an
 # independent environment and may:
@@ -89,10 +88,8 @@ def trips_and_zones(
         Model(
             # Specify the model identifier with the first positional arg or `name` kwarg.
             "taxi_fhvhv",
-
             # Specify specific columns to read with the `projection_schema` parameter.
             projection_schema=TripColumns,
-
             # Specify filtering for rows to retrieve with the `filter` parameter.
             filter="pickup_datetime >= '2022-12-15T00:00:00-05:00' AND pickup_datetime < '2023-01-01T00:00:00-05:00'",
         ),

--- a/examples/learn/02-data-quality-expectations/README.md
+++ b/examples/learn/02-data-quality-expectations/README.md
@@ -34,6 +34,7 @@ import pyarrow
 from bauplan import Model
 from bauplan.standard_expectations import expect_column_no_nulls
 
+
 @bauplan.expectation()
 @bauplan.python("3.11")
 def test_null_values_on_scene_datetime(

--- a/examples/learn/02-data-quality-expectations/pipeline/expectations.py
+++ b/examples/learn/02-data-quality-expectations/pipeline/expectations.py
@@ -24,7 +24,6 @@ from bauplan.standard_expectations import expect_column_no_nulls
 
 # Expectations are identified by a special decorator.
 @bauplan.expectation()
-
 # You can use this to specify the python version used during execution.
 @bauplan.python("3.11")
 def test_null_values_on_scene_datetime(

--- a/examples/learn/02-data-quality-expectations/pipeline/models.py
+++ b/examples/learn/02-data-quality-expectations/pipeline/models.py
@@ -34,18 +34,18 @@ class TripTimestamps(TableSchema):
 class NormalizedTaxiTripsSchema(TableSchema):
     """Trip timestamps enriched with the borough and zone of the pickup location."""
 
-    PULocationID: Annotated[Int64, TableField(lineage=TripTimestamps['PULocationID'])]
+    PULocationID: Annotated[Int64, TableField(lineage=TripTimestamps["PULocationID"])]
     request_datetime: Annotated[
-        TimestampMicroUTC, TableField(lineage=TripTimestamps['request_datetime'])
+        TimestampMicroUTC, TableField(lineage=TripTimestamps["request_datetime"])
     ]
     on_scene_datetime: Annotated[
-        TimestampMicroUTC, TableField(lineage=TripTimestamps['on_scene_datetime'])
+        TimestampMicroUTC, TableField(lineage=TripTimestamps["on_scene_datetime"])
     ]
     pickup_datetime: Annotated[
-        TimestampMicroUTC, TableField(lineage=TripTimestamps['pickup_datetime'])
+        TimestampMicroUTC, TableField(lineage=TripTimestamps["pickup_datetime"])
     ]
     dropoff_datetime: Annotated[
-        TimestampMicroUTC, TableField(lineage=TripTimestamps['dropoff_datetime'])
+        TimestampMicroUTC, TableField(lineage=TripTimestamps["dropoff_datetime"])
     ]
     Borough: Annotated[String, TableField(lineage="taxi_zones['Borough']")]
     Zone: Annotated[String, TableField(lineage="taxi_zones['Zone']")]
@@ -93,7 +93,9 @@ class TaxiTripWaitingTimesSchema(TableSchema):
     service_zone: String
     waiting_time_minutes: Annotated[
         Int64,
-        TableField(doc="Whole minutes elapsed between request_datetime and on_scene_datetime."),
+        TableField(
+            doc="Whole minutes elapsed between request_datetime and on_scene_datetime."
+        ),
     ]
 
 
@@ -132,9 +134,7 @@ class ZoneAvgWaitingTimesSchema(TableSchema):
 @bauplan.model(materialization_strategy="REPLACE")
 @bauplan.python("3.12", pip={"polars": "1.38.1"})
 def zone_avg_waiting_times(
-    taxi_trip_waiting_times: Annotated[
-        pyarrow.Table, Model("taxi_trip_waiting_times")
-    ],
+    taxi_trip_waiting_times: Annotated[pyarrow.Table, Model("taxi_trip_waiting_times")],
 ) -> Annotated[pyarrow.Table, ZoneAvgWaitingTimesSchema]:
     import polars as pl
 

--- a/examples/learn/03-safe-ingestion-on-a-schedule/safe_ingestion_flow.py
+++ b/examples/learn/03-safe-ingestion-on-a-schedule/safe_ingestion_flow.py
@@ -32,32 +32,35 @@ def source_to_iceberg_table(
 ):
     """Wrap the table creation and upload process in Bauplan."""
     get_transaction().set("bauplan_ingestion_branch", bauplan_ingestion_branch)
-    
+
     # Since this is a demo, we'll delete the branch and recreate it from scratch.
     bauplan_client.delete_branch(bauplan_ingestion_branch, if_exists=True)
 
     # Create the branch from main HEAD.
     bauplan_client.create_branch(bauplan_ingestion_branch, from_ref="main")
-    
+
     # We check if the branch is there.
     assert bauplan_client.has_branch(bauplan_ingestion_branch), "Branch not found"
-    
+
     # Ensure the namespace exists on the branch, create it if not.
-    if not bauplan_client.has_namespace(namespace=namespace, ref=bauplan_ingestion_branch):
+    if not bauplan_client.has_namespace(
+        namespace=namespace, ref=bauplan_ingestion_branch
+    ):
         print(f"Namespace '{namespace}' not found, creating it...")
-        bauplan_client.create_namespace(namespace=namespace, branch=bauplan_ingestion_branch)
-    
+        bauplan_client.create_namespace(
+            namespace=namespace, branch=bauplan_ingestion_branch
+        )
+
     # Now we create the table in the branch.
     bauplan_client.create_table(
         table=table_name,
         search_uri=source_s3_pattern,
         namespace=namespace,
         branch=bauplan_ingestion_branch,
-        
         # Just in case the test table is already there for other reasons.
         replace=True,
     )
-    
+
     # We check if the table is there.
     fq_name = f"{namespace}.{table_name}"
     assert bauplan_client.has_table(table=fq_name, ref=bauplan_ingestion_branch), (
@@ -75,7 +78,10 @@ def source_to_iceberg_table(
 
 @task(cache_policy=NONE)
 def run_quality_checks(
-    bauplan_client: bauplan.Client, bauplan_ingestion_branch: str, table_name: str, namespace: str
+    bauplan_client: bauplan.Client,
+    bauplan_ingestion_branch: str,
+    table_name: str,
+    namespace: str,
 ):
     """
     This task uses the Bauplan SDK to query the data as an Arrow table,
@@ -83,13 +89,13 @@ def run_quality_checks(
     operations.
     """
     get_transaction().set("bauplan_ingestion_branch", bauplan_ingestion_branch)
-    
+
     # We retrieve the data and check if the column has no nulls.
     # Make sure the column you're checking is in
     # the table, so change this appropriately
     # if you're using a different dataset
     column_to_check = "Age"
-    
+
     # NOTE: If you don't want to use any SQL, you
     # can interact with the lakehouse in pure Python
     # and still get back an Arrow table (for this one
@@ -161,7 +167,6 @@ def safe_ingestion_with_bauplan(
     print(f"Using ingestion branch: {bauplan_ingestion_branch}")
     # Start a Prefect transaction.
     with transaction():
-        
         ### Write ###
         # First, ingest data from the S3 source
         # into a table on the Bauplan branch.
@@ -172,13 +177,16 @@ def safe_ingestion_with_bauplan(
             source_s3_pattern,
             bauplan_ingestion_branch,
         )
-        
+
         ### Audit ###
         # We query the table in the branch and check we have no nulls.
         run_quality_checks(
-            bauplan_client, bauplan_ingestion_branch, table_name=table_name, namespace=namespace
+            bauplan_client,
+            bauplan_ingestion_branch,
+            table_name=table_name,
+            namespace=namespace,
         )
-        
+
         ### Publish ###
         # Finally, we merge the branch into the main
         # branch if the quality checks passed.
@@ -195,20 +203,22 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    
+
     # Table_name and s3_path are the main arguments from the command line.
     # The ingestion branch is auto-generated from the authenticated username.
     parser.add_argument("--table_name", type=str, default="titanic_from_prefect")
-    parser.add_argument("--s3_path", type=str, default="s3://alpha-hello-bauplan/titanic.csv")
+    parser.add_argument(
+        "--s3_path", type=str, default="s3://alpha-hello-bauplan/titanic.csv"
+    )
     parser.add_argument("--namespace", type=str, default="prefect")
     args = parser.parse_args()
 
     # The name of the table we will be ingesting data into.
     table_name = args.table_name
-    
+
     # Namespace for the table: note that bauplan is the default.
     namespace = args.namespace
-    
+
     # The S3 pattern for the data we want to ingest.
     # NOTE: If you're using Bauplan Alpha environment,
     # this should be a publicly accessible path
@@ -217,7 +227,7 @@ if __name__ == "__main__":
     print(
         f"Starting the safe ingestion flow with the following parameters: {table_name}, {s3_path}"
     )
-    
+
     safe_ingestion_with_bauplan(
         source_s3_pattern=s3_path,
         table_name=table_name,

--- a/examples/learn/04-using-llms-with-secrets/README.md
+++ b/examples/learn/04-using-llms-with-secrets/README.md
@@ -28,11 +28,11 @@ from typing import Annotated
 
 from bauplan import Model, Parameter
 
+
 def sec_10_q_tabular_dataset(
     data: Annotated[pyarrow.Table, Model("sec_10_q_markdown")],
     open_ai_key: Annotated[str, Parameter("openai_api_key")],  # decrypted at runtime
-):
-    ...
+): ...
 ```
 
 Secrets are set at the project level, so you can experiment on a development branch without re-setting them.

--- a/examples/learn/04-using-llms-with-secrets/app/explore_analysis.py
+++ b/examples/learn/04-using-llms-with-secrets/app/explore_analysis.py
@@ -15,6 +15,7 @@ bauplan_client = bauplan.Client()
 
 ### Utility Functions ###
 
+
 @st.cache_data()
 def query_as_arrow(_client: bauplan.Client, sql: str, namespace: str):
     """
@@ -62,7 +63,7 @@ def plot_bar_chart(statements: list, means: list):
 
 def main(analysis_table_name: str, namespace: str):
     st.title("Explore the data extracted from the PDFs!")
-    
+
     # Check that the table exists before querying.
     full_table_name = f"{namespace}.{analysis_table_name}"
     if not bauplan_client.has_table(full_table_name, ref="main"):
@@ -85,7 +86,6 @@ def main(analysis_table_name: str, namespace: str):
 
 
 if __name__ == "__main__":
-    
     # Parse the arguments.
     import argparse
 
@@ -93,6 +93,6 @@ if __name__ == "__main__":
     parser.add_argument("--analysis_table_name", type=str, default="sec_10_q_analysis")
     parser.add_argument("--namespace", type=str, default="my_pdfs")
     args = parser.parse_args()
-    
+
     # Start the app.
     main(args.analysis_table_name, args.namespace)

--- a/examples/learn/04-using-llms-with-secrets/bpln_pipeline/dag.py
+++ b/examples/learn/04-using-llms-with-secrets/bpln_pipeline/dag.py
@@ -81,7 +81,7 @@ def _pdf_to_markdown(bucket, pdf_path):
         print(f"\n>>>> Processing {pdf_path.split('/')[-1]}")
         s3.download_fileobj(bucket, pdf_path, tmp_file)
         result = md.convert(tmp_file.name)
-        
+
         # Cut the text after the forward-looking statements.
         return result.text_content.split("Forward-Looking Statements")[0]
 
@@ -119,7 +119,7 @@ def sec_10_q_markdown(
     # Get lists from the Arrow columns, to iterate over them.
     bucket_name = data["bucket"].to_pylist()
     object_key = data["pdf_path"].to_pylist()
-    
+
     # We will store the markdown text in a list.
     values = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=12) as executor:
@@ -133,10 +133,10 @@ def sec_10_q_markdown(
                 raise ex
 
     values, _ = zip(*sorted(values, key=lambda x: x[1]))
-    
+
     # Add the markdown text to the data.
     data = data.append_column("markdown_text", [values])
-    
+
     # Remove the bucket and path columns.
     data = data.drop_columns(["bucket", "pdf_path"])
 
@@ -191,15 +191,14 @@ def sec_10_q_tabular_dataset(
     results = []
     oai_client = OpenAI(api_key=open_ai_key)
     for company, year, quarter, t in zip(companies, years, quarters, text):
-        
         # Use the LLM to extract the required information.
         generated_result = _request_prediction_from_open_ai(
             company, year, quarter, t, oai_client
         )
-        
+
         # Parse the JSON response to get the rows.
         rows = generated_result.model_dump(mode="json")["statements"]
-        
+
         # Add the original metadata regarding the report to each row.
         for row in rows:
             row["report_company"] = company
@@ -207,7 +206,7 @@ def sec_10_q_tabular_dataset(
             row["report_quarter"] = quarter
         results.extend(rows)
     end_time = time.time()
-    
+
     # Print the time taken to process the documents.
     print(
         f"LLM loop time: {end_time - start_time} s, avg. {(end_time - start_time) / len(results)} s"
@@ -247,7 +246,7 @@ def sec_10_q_analysis(
 
     # Convert the Arrow table to a Polars DataFrame (zero-copy).
     df = pl.from_arrow(data)
-    
+
     # Group by company and statement, and calculate the mean of the USD values.
     df = df.group_by("report_company", "statement").agg(pl.col("usd").mean())
 

--- a/examples/learn/04-using-llms-with-secrets/run.py
+++ b/examples/learn/04-using-llms-with-secrets/run.py
@@ -211,9 +211,7 @@ if __name__ == "__main__":
     parser.add_argument("--s3_metadata_folder", type=str, default="my_pdf_metadata")
     parser.add_argument("--table_name", type=str, default="my_pdf_metadata")
     parser.add_argument("--namespace", type=str, default="my_pdfs")
-    parser.add_argument(
-        "--ingestion_branch", type=str, required=True
-    )
+    parser.add_argument("--ingestion_branch", type=str, required=True)
     args = parser.parse_args()
     # Run the upload and processing.
     upload_and_process(

--- a/examples/learn/05-advanced-git-for-data/git_for_data_tour.py
+++ b/examples/learn/05-advanced-git-for-data/git_for_data_tour.py
@@ -124,7 +124,7 @@ def main(file_path: str):
     # ── audit ────────────────────────────────────────────────────────
 
     _step(5, TOTAL, f"Auditing commit history for author '{full_name}'...")
-    
+
     if not full_name:
         my_author_commit_history = client.get_commits(
             my_branch_name, filter_by_username=username, limit=5

--- a/examples/learn/07-how-to-manage-conflicts/01_concurrency_conflict/pipelines/avg_fare/models.py
+++ b/examples/learn/07-how-to-manage-conflicts/01_concurrency_conflict/pipelines/avg_fare/models.py
@@ -31,9 +31,7 @@ class AverageFareSchema(TableSchema):
 @bauplan.python("3.12", pip={"polars": "1.37"})
 @bauplan.model(materialization_strategy="REPLACE")
 def workshop_average_fares(
-    data: Annotated[
-        pyarrow.Table, Model("titanic", projection_schema=PassengerFare)
-    ],
+    data: Annotated[pyarrow.Table, Model("titanic", projection_schema=PassengerFare)],
 ) -> Annotated[pyarrow.Table, AverageFareSchema]:
     """Compute the mean Titanic fare for each passenger class."""
     import polars as pl

--- a/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/main.py
+++ b/examples/learn/07-how-to-manage-conflicts/04_corruption_conflict/main.py
@@ -70,6 +70,7 @@ def fix_and_backfill(
         )
         print(f"  [fix] Backfilled {year}")
 
+
 def main(
     profile: Annotated[str, typer.Option(help="Bauplan profile to use")] = "default",
 ) -> None:

--- a/examples/learn/08-ingestion-and-transformation-with-dagster/src/transformation/pipelines/account_summary/models.py
+++ b/examples/learn/08-ingestion-and-transformation-with-dagster/src/transformation/pipelines/account_summary/models.py
@@ -63,7 +63,9 @@ class DailyAccountSpendSchema(TableSchema):
     account_id: String
     date: Date32
     total_amount: Annotated[Float64, TableField(doc="Sum of settled amounts.")]
-    transaction_count: Annotated[Int64, TableField(doc="Number of settled transactions.")]
+    transaction_count: Annotated[
+        Int64, TableField(doc="Number of settled transactions.")
+    ]
     avg_amount: Annotated[Float64, TableField(doc="Mean settled amount.")]
 
 

--- a/examples/projects/RAG-service-support-agent/pipeline/models.py
+++ b/examples/projects/RAG-service-support-agent/pipeline/models.py
@@ -12,12 +12,10 @@ import bauplan
 def one_big_qa_table(
     questions=bauplan.Model(
         "stack_overflow_questions",
-        
         # We leverage the columnar nature of the
         # platform to only select the columns we
         # need.
         columns=["id", "title", "body"],
-        
         # We filter out all the questions submitted before a certain date
         # to showcase parametrized filter pushdown
         # to the data lake in a declarative way.
@@ -32,7 +30,6 @@ def one_big_qa_table(
             "parentid",  # need for the join
             "body",
         ],
-        
         # Answers cannot be created before the questions,
         # so the filter should be pushed down also here.
         filter="creationdate > $creation_date_start",
@@ -53,10 +50,10 @@ def one_big_qa_table(
     |-----------------|----------------|--------------|------------------|
     | 1               | How to...      | You d..      | [python, pandas] |
     """
-    
+
     # Print out the number of rows retrieved to the console.
     print(f"\n\n===> Number of questions retrieved: {questions.num_rows}\n\n")
-    
+
     # We use the duckdb library to quickly and concisely complete the join.
     import duckdb
 
@@ -83,7 +80,7 @@ def one_big_qa_table(
     """
     data = duckdb.sql(sql_query).arrow()
     print(f"\n\n===> Total big table size: {data.num_rows}\n\n")
-    
+
     # As in every bauplan model, functions return a "dataframe-like" object,
     # in this case, an Arrow table.
     return data
@@ -99,7 +96,6 @@ def one_big_qa_table(
 )
 # Note: We enable internet access to connect to our Pinecone cluster!
 @bauplan.model(
-    
     # We can override the default name of the model in the catalog by
     # specifying the name parameter.
     name="one_big_qa_table_with_embeddings",
@@ -108,7 +104,6 @@ def one_big_qa_table(
 )
 def q_and_a_to_rag(
     big_table=bauplan.Model("one_big_qa_table"),
-    
     # Read in securely the Pinecone API key.
     pinecone_key=bauplan.Parameter("pinecone_key"),
 ):
@@ -128,7 +123,7 @@ def q_and_a_to_rag(
     # Utility functions live in utils.py to
     # keep this module focused on the DAG structure.
     from utils import tsne_analysis
-    
+
     # We connect to Pinecone to get the embeddings.
     from pinecone_utils import (
         get_text_embeddings_from_pinecone,
@@ -138,7 +133,7 @@ def q_and_a_to_rag(
 
     # Initialize a Pinecone client with your API key.
     pc = Pinecone(api_key=pinecone_key)
-    
+
     # Concatenate the question and answer text to embed them together.
     # Put a limit to the length of the text to embed for convenience.
     text_to_embed = [
@@ -150,10 +145,10 @@ def q_and_a_to_rag(
     print("\n\n=====> Start getting the embeddings from Pinecone...\n")
     text_embeddings = get_text_embeddings_from_pinecone(pc, text_to_embed)
     print("\n\n=====> Finished getting the embeddings from Pinecone!\n")
-    
+
     # Get the vectors out of the Pinecone return object.
     _vectors = [e["values"] for e in text_embeddings]
-    
+
     # Now we compute the 2D embeddings with TSNE.
     two_d_embeddings = tsne_analysis(np.array(_vectors))
     assert (
@@ -162,7 +157,7 @@ def q_and_a_to_rag(
         == len(text_embeddings)
         == len(_vectors)
     )
-    
+
     # Upload to Pinecone.
     print("\n\n=====> Start the Pinecone upsert process...\n")
     num_doc_inserted = upload_documents_to_pinecone(
@@ -173,7 +168,7 @@ def q_and_a_to_rag(
     )
     print(f"\nInserted {num_doc_inserted} documents in Pinecone")
     print("\n\n=====> Finished the Pinecone upload process!\n")
-    
+
     # Add the embeddings and their 2D version to the table before returning it.
     final_table = big_table.append_column("embeddings", [_vectors])
     final_table = final_table.append_column(

--- a/examples/projects/RAG-service-support-agent/pipeline/pinecone_utils.py
+++ b/examples/projects/RAG-service-support-agent/pipeline/pinecone_utils.py
@@ -51,10 +51,10 @@ def upload_documents_to_pinecone(
                 "field_map": {"text": "chunk_text"},
             },
         )
-    
+
     # Get the index object.
     index = pinecone_client.Index(index_name)
-    
+
     # Prepare the records for upsert, trying not
     # to exceed the max supported size.
     tot_records = 0

--- a/examples/projects/build-a-playlist-recommender/app/explore_and_recommend.py
+++ b/examples/projects/build-a-playlist-recommender/app/explore_and_recommend.py
@@ -37,6 +37,7 @@ bauplan_client = bauplan.Client()
 
 ### Utility Functions ###
 
+
 @st.cache_data()
 def query_as_arrow(
     _client: bauplan.Client,
@@ -138,6 +139,7 @@ def vector_search(database, query_vector, index_name, collection_name, limit=5):
 
 ### The Streamlit App Begins Here ###
 
+
 def main(one_big_table_name: str, index_name: str, collection_name: str):
     st.title("Explore the vector space and get recommendations!")
 
@@ -147,7 +149,7 @@ def main(one_big_table_name: str, index_name: str, collection_name: str):
             "The Mongo search index is not available yet. Please wait a bit and try again!"
         )
         st.stop()
-    
+
     # Automatically infer the bauplan username from the authenticated client.
     bauplan_user_name = bauplan_client.info().user.username
     all_branches = list(
@@ -179,16 +181,16 @@ def main(one_big_table_name: str, index_name: str, collection_name: str):
     tracks_to_author = dict(
         zip(table["_id"].to_pylist(), table["artist_name"].to_pylist())
     )
-    
+
     # We highlight a few authors for the scatterplot.
     target_authors = ["Drake", "Kanye West", "Justin Bieber", "Ed Sheeran", "Eminem"]
-    
+
     # We mark as unknown the tracks not written by the target authors, so that
     # the visualization is more readable.
     for t, a in tracks_to_author.items():
         if a not in target_authors:
             tracks_to_author[t] = "unknown"
-    
+
     # Plot the embeddings, color-coded by author.
     plot_scatterplot_with_lookup(
         title="Music in (vector) space",
@@ -227,12 +229,12 @@ if __name__ == "__main__":
         "--one_big_table_name", type=str, default="track_vectors_with_metadata"
     )
     args = parser.parse_args()
-    
+
     # These are hardcoded to the same values as in the pipeline.
     # Change them here if you change them in the pipeline.
     COLLECTION_NAME = "track_vectors"
     INDEX_NAME = "bauplan_recs_index"
-    
+
     # Start the app.
     main(
         one_big_table_name=args.one_big_table_name,

--- a/examples/projects/build-a-playlist-recommender/pipeline/models.py
+++ b/examples/projects/build-a-playlist-recommender/pipeline/models.py
@@ -8,12 +8,10 @@ import bauplan
 def playlists_to_sequences(
     tracks=bauplan.Model(
         "spotify_playlists",
-        
         # We leverage the columnar nature of the
         # platform to only select the columns we
         # need.
         columns=["playlist_id", "track_uri", "pos"],
-        
         # We filter out the playlists with less
         # than 5 tracks and less than 2 followers.
         # Bauplan is smart enough to push this filter down to the lakehouse.
@@ -32,10 +30,10 @@ def playlists_to_sequences(
     | 112             | [1, 2, 3] |
     | 341             | [4, 5]    |
     """
-    
+
     # Print out the number of rows retrieved to the console.
     print("\n\n===> Number of tracks retrieved: ", tracks.num_rows)
-    
+
     # We use the duckdb library to quickly and concisely complete the group by.
     import duckdb
 
@@ -49,7 +47,7 @@ def playlists_to_sequences(
     ORDER BY 1 ASC
     """
     data = duckdb.sql(sql_query).arrow()
-    
+
     # We print out the number of rows returned by the query
     # due to the GROUP BY.
     print("\n\n===> Number of playlists: ", data.num_rows)
@@ -62,10 +60,8 @@ def playlists_to_sequences(
 @bauplan.python("3.11", pip={"duckdb": "1.0.0"})
 @bauplan.model()
 def popular_tracks(
-    
     # We re-use the playlists_to_sequences model as an input.
     playlists_to_sequences=bauplan.Model("playlists_to_sequences"),
-    
     # We take an additional parameter to filter the top k tracks.
     top_k=bauplan.Parameter("top_k"),
 ):
@@ -93,7 +89,7 @@ def popular_tracks(
     LIMIT {top_k}
     """
     rows = duckdb.sql(sql_query).arrow()
-    
+
     # Double-check the number of rows returned == top_k.
     assert rows.num_rows == top_k
     return rows
@@ -117,17 +113,14 @@ def popular_tracks(
 def track_vectors_with_metadata(
     playlists_to_sequences=bauplan.Model("playlists_to_sequences"),
     popular_tracks=bauplan.Model("popular_tracks"),
-    
     # Extract metadata for user-facing purposes.
     metadata=bauplan.Model(
         "spotify_playlists",
         columns=["track_name", "artist_name", "track_uri"],
-        
         # For consistency, we filter out the tracks
         # with the same criteria as before.
         filter="num_followers > $num_followers and num_tracks > $num_tracks",
     ),
-    
     # This will read the secret in and decrypt it ONLY in the secure worker
     # at runtime!
     mongo_uri=bauplan.Parameter("mongo_uri"),
@@ -158,11 +151,11 @@ def track_vectors_with_metadata(
     print(f"Trained a total of {len(model)} vectors!")
     top_k_track_id = popular_tracks["track_id"].to_pylist()
     top_k_tracks_embeddings = np.array([model[t] for t in top_k_track_id])
-    
+
     # Now we compute the 2D embeddings with TSNE.
     two_d_embeddings = tsne_analysis(top_k_tracks_embeddings)
     assert len(two_d_embeddings) == len(top_k_track_id)
-    
+
     # Temp table, before joining with the content embeddings.
     table = pa.Table.from_pydict(
         {
@@ -196,7 +189,7 @@ def track_vectors_with_metadata(
     """
     duckdb.register("track_table", table)
     final_table = duckdb.sql(sql_query).arrow()
-    
+
     # There should should be at most `top_k` rows in the final table.
     print(f"Final One Big Table has {final_table.num_rows} rows.")
 

--- a/examples/projects/build-a-playlist-recommender/pipeline/mongo_utils.py
+++ b/examples/projects/build-a-playlist-recommender/pipeline/mongo_utils.py
@@ -26,14 +26,14 @@ def upload_vectors_to_mongodb(
         db = client[db_name]
         if collection_name in db.list_collection_names():
             db[collection_name].drop()
-        
+
         # Create a new collection.
         collection = db[collection_name]
-        
+
         # Insert the table in the MongoDB collection
         # by converting it to a list of dictionaries.
         result = collection.insert_many(_table.to_pylist())
-        
+
         # Create a search index for the vectors.
         # Example from: https://www.mongodb.com/
         # docs/languages/python/pymongo-driver/
@@ -43,7 +43,6 @@ def upload_vectors_to_mongodb(
                 "fields": [
                     {
                         "type": "vector",
-                        
                         # This should match the
                         # dimensionality of the vectors.
                         "numDimensions": 48,

--- a/examples/projects/from-notebooks-to-prod/README.md
+++ b/examples/projects/from-notebooks-to-prod/README.md
@@ -48,6 +48,7 @@ The key trick is marimo's `@app.function` decorator. Functions marked with it ar
 def join_taxi_tables(table_1, table_2):
     return table_1.join(table_2, ...)
 
+
 # in models.py (Bauplan pipeline)
 from taxi_notebook import join_taxi_tables
 ```

--- a/examples/projects/from-notebooks-to-prod/pipeline/models.py
+++ b/examples/projects/from-notebooks-to-prod/pipeline/models.py
@@ -34,7 +34,7 @@ class TripsAndZonesSchema(TableSchema):
 
     pickup_datetime: Annotated[
         TimestampMicroUTC,
-        TableField(lineage=TripColumns['pickup_datetime']),
+        TableField(lineage=TripColumns["pickup_datetime"]),
     ]
     PULocationID: Annotated[
         Int64,
@@ -43,11 +43,11 @@ class TripsAndZonesSchema(TableSchema):
                 "Pickup location. The join is a full outer join with coalesce, so this "
                 "column carries taxi_zones' LocationID for zones with no trips."
             ),
-            lineage=TripColumns['PULocationID'],
+            lineage=TripColumns["PULocationID"],
         ),
     ]
-    trip_miles: Annotated[Float64, TableField(lineage=TripColumns['trip_miles'])]
-    Zone: Annotated[String, TableField(lineage=ZoneColumns['Zone'])]
+    trip_miles: Annotated[Float64, TableField(lineage=TripColumns["trip_miles"])]
+    Zone: Annotated[String, TableField(lineage=ZoneColumns["Zone"])]
 
 
 @bauplan.model()
@@ -79,7 +79,9 @@ def trips_and_zones(
 class StatsByTaxiZoneSchema(TableSchema):
     """Median log-transformed trip distance per pickup zone."""
 
-    Zone: Annotated[String, TableField(doc="Pickup zone the statistics are grouped by.")]
+    Zone: Annotated[
+        String, TableField(doc="Pickup zone the statistics are grouped by.")
+    ]
     log_trip_miles: Annotated[
         Float64,
         TableField(

--- a/examples/projects/from-notebooks-to-prod/pipeline/taxi_notebook.py
+++ b/examples/projects/from-notebooks-to-prod/pipeline/taxi_notebook.py
@@ -88,7 +88,7 @@ def compute_stats_by_zone(df: pl.DataFrame) -> pl.DataFrame:
 
     # Clean up the dataset by excluding certain rows.
     time_filter = datetime(2022, 1, 1, tzinfo=timezone.utc)
-    
+
     # Filter df by timestamp, exclude rows with
     # trip_miles = 0 and trip_miles > 200.
     df = df.filter(

--- a/examples/projects/medallion-for-telemetry-data/pipeline/models.py
+++ b/examples/projects/medallion-for-telemetry-data/pipeline/models.py
@@ -41,7 +41,9 @@ class SignalCleanSchema(TableSchema):
             doc="Reading time, shifted to UTC and stored without a timezone.",
         ),
     ]
-    signal: Annotated[String, TableField(doc="Sensor name; the bronze `sensors` column.")]
+    signal: Annotated[
+        String, TableField(doc="Sensor name; the bronze `sensors` column.")
+    ]
     value: Annotated[Float64, TableField(doc="Reading parsed out of the raw text.")]
     value_original: Annotated[
         Float64, TableField(doc="The parsed reading before any downstream correction.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
-dependencies = ["bauplan-sdk-types~=0.1"]
+dependencies = ["bauplan-sdk-types~=0.2.0"]
 
 [project.urls]
 Documentation = "https://docs.bauplanlabs.com/"

--- a/python/bauplan/schema.pyi
+++ b/python/bauplan/schema.pyi
@@ -383,6 +383,11 @@ class Table:
         """
         The fully qualified name: `namespace.name`.
         """
+    @property
+    def comment(self, /) -> str | None:
+        """
+        The table documentation, carried as the `comment` table property.
+        """
     def is_managed(self, /) -> bool:
         """
         Whether this is a managed table.
@@ -469,6 +474,11 @@ class TableField:
     A field in a table schema.
     """
     def __repr__(self, /) -> str: ...
+    @property
+    def doc(self, /) -> str | None:
+        """
+        The field documentation.
+        """
     @property
     def id(self, /) -> int:
         """

--- a/src/api/table.rs
+++ b/src/api/table.rs
@@ -31,6 +31,9 @@ pub struct TableField {
     pub required: bool,
     /// The field type.
     pub r#type: String,
+    /// The field documentation.
+    #[serde(default)]
+    pub doc: Option<String>,
 }
 
 /// A partition field on a table.
@@ -121,6 +124,11 @@ impl Table {
     pub fn fqn(&self) -> String {
         format!("{}.{}", self.namespace, self.name)
     }
+
+    /// The table documentation, carried as the `comment` table property.
+    pub fn comment(&self) -> Option<&str> {
+        self.properties.get("comment").map(String::as_str)
+    }
 }
 
 #[cfg(feature = "python")]
@@ -130,6 +138,12 @@ impl Table {
     #[getter(fqn)]
     fn py_fqn(&self) -> String {
         self.fqn()
+    }
+
+    /// The table documentation, carried as the `comment` table property.
+    #[getter(comment)]
+    fn py_comment(&self) -> Option<&str> {
+        self.comment()
     }
 
     /// Whether this is a managed table.

--- a/src/cli/init/models.py
+++ b/src/cli/init/models.py
@@ -9,18 +9,16 @@ class SurvivalColumns(bauplan.TableSchema):
     """A projection of 2 columns for survival rate analysis."""
 
     Age: Annotated[
-        bauplan.Float64,
+        bauplan.Float64 | None,
         bauplan.TableField(
             doc="A passenger's age in years according to the solar calendar.",
-            lineage="titanic['Age']",
         ),
     ]
 
     Survived: Annotated[
-        bauplan.Int64,
+        bauplan.Int64 | None,
         bauplan.TableField(
             doc="Indicator of passenger's survival; may be 1 (survived) or 0 (did not).",
-            lineage="titanic['Survived']",
         ),
     ]
 
@@ -29,7 +27,7 @@ class SurvivalRateSchema(bauplan.TableSchema):
     """Analysis result of passenger survival rate by age (grouped by year)."""
 
     Age: Annotated[
-        bauplan.Float64,
+        bauplan.Float64 | None,
         bauplan.TableField(
             doc="Passenger age group by year.",
             lineage=SurvivalColumns["Age"],
@@ -37,7 +35,7 @@ class SurvivalRateSchema(bauplan.TableSchema):
     ]
 
     survival_rate: Annotated[
-        bauplan.Float64,
+        bauplan.Float64 | None,
         bauplan.TableField(
             doc="Likelihood of passenger survival for a given age group (by year).",
             lineage=SurvivalColumns["Survived"],

--- a/src/cli/table.rs
+++ b/src/cli/table.rs
@@ -428,17 +428,26 @@ fn handle_get_table(
             println!();
         }
         Output::Tty => {
+            if let Some(comment) = resp.comment() {
+                println!("Table Documentation:\n{comment}\n");
+            }
+
             let mut tw = TabWriter::new(stdout());
-            writeln!(&mut tw, "NAME\tREQUIRED\tTYPE")?;
+            writeln!(&mut tw, "NAME\tREQUIRED\tTYPE\tDOC")?;
 
             for TableField {
                 name,
                 required,
                 r#type,
+                doc,
                 ..
             } in resp.fields
             {
-                writeln!(&mut tw, "{name}\t{required}\t{type}")?;
+                writeln!(
+                    &mut tw,
+                    "{name}\t{required}\t{type}\t{}",
+                    doc.as_deref().unwrap_or("-")
+                )?;
             }
 
             tw.flush()?;

--- a/tests/fixtures/assert_in_expectation/models.py
+++ b/tests/fixtures/assert_in_expectation/models.py
@@ -16,32 +16,39 @@ from bauplan import (
 class QueryModelSchema(TableSchema):
     """The columns query_model selects from taxi_fhvhv."""
 
-    pickup_datetime: TimestampMicroUTC
-    dropoff_datetime: TimestampMicroUTC
-    PULocationID: Int64
-    DOLocationID: Int64
-    trip_miles: Float64
-    trip_time: Int64
-    base_passenger_fare: Float64
-    tolls: Float64
-    sales_tax: Float64
-    tips: Float64
+    pickup_datetime: TimestampMicroUTC | None
+    dropoff_datetime: TimestampMicroUTC | None
+    PULocationID: Int64 | None
+    DOLocationID: Int64 | None
+    trip_miles: Float64 | None
+    trip_time: Int64 | None
+    base_passenger_fare: Float64 | None
+    tolls: Float64 | None
+    sales_tax: Float64 | None
+    tips: Float64 | None
 
 
 class TripMilesPushdown(TableSchema):
     """The single column the expectation reads from query_model."""
 
-    trip_miles: Annotated[Float64, TableField(lineage=QueryModelSchema["trip_miles"])]
+    trip_miles: Annotated[
+        Float64 | None, TableField(lineage=QueryModelSchema["trip_miles"])
+    ]
 
 
 class NormalizedTripsSchema(TableSchema):
     """The trip columns normalize_data reads from query_model and passes through."""
 
-    trip_time: Annotated[Int64, TableField(lineage=QueryModelSchema["trip_time"])]
-    pickup_datetime: Annotated[
-        TimestampMicroUTC, TableField(lineage=QueryModelSchema["pickup_datetime"])
+    trip_time: Annotated[
+        Int64 | None, TableField(lineage=QueryModelSchema["trip_time"])
     ]
-    trip_miles: Annotated[Float64, TableField(lineage=QueryModelSchema["trip_miles"])]
+    pickup_datetime: Annotated[
+        TimestampMicroUTC | None,
+        TableField(lineage=QueryModelSchema["pickup_datetime"]),
+    ]
+    trip_miles: Annotated[
+        Float64 | None, TableField(lineage=QueryModelSchema["trip_miles"])
+    ]
 
 
 @bauplan.expectation()

--- a/tests/fixtures/expectation_returns_int/models.py
+++ b/tests/fixtures/expectation_returns_int/models.py
@@ -16,32 +16,39 @@ from bauplan import (
 class QueryModelSchema(TableSchema):
     """The columns query_model selects from taxi_fhvhv."""
 
-    pickup_datetime: TimestampMicroUTC
-    dropoff_datetime: TimestampMicroUTC
-    PULocationID: Int64
-    DOLocationID: Int64
-    trip_miles: Float64
-    trip_time: Int64
-    base_passenger_fare: Float64
-    tolls: Float64
-    sales_tax: Float64
-    tips: Float64
+    pickup_datetime: TimestampMicroUTC | None
+    dropoff_datetime: TimestampMicroUTC | None
+    PULocationID: Int64 | None
+    DOLocationID: Int64 | None
+    trip_miles: Float64 | None
+    trip_time: Int64 | None
+    base_passenger_fare: Float64 | None
+    tolls: Float64 | None
+    sales_tax: Float64 | None
+    tips: Float64 | None
 
 
 class TripMilesPushdown(TableSchema):
     """The single column the expectation reads from query_model."""
 
-    trip_miles: Annotated[Float64, TableField(lineage=QueryModelSchema["trip_miles"])]
+    trip_miles: Annotated[
+        Float64 | None, TableField(lineage=QueryModelSchema["trip_miles"])
+    ]
 
 
 class NormalizedTripsSchema(TableSchema):
     """The trip columns normalize_data reads from query_model and passes through."""
 
-    trip_time: Annotated[Int64, TableField(lineage=QueryModelSchema["trip_time"])]
-    pickup_datetime: Annotated[
-        TimestampMicroUTC, TableField(lineage=QueryModelSchema["pickup_datetime"])
+    trip_time: Annotated[
+        Int64 | None, TableField(lineage=QueryModelSchema["trip_time"])
     ]
-    trip_miles: Annotated[Float64, TableField(lineage=QueryModelSchema["trip_miles"])]
+    pickup_datetime: Annotated[
+        TimestampMicroUTC | None,
+        TableField(lineage=QueryModelSchema["pickup_datetime"]),
+    ]
+    trip_miles: Annotated[
+        Float64 | None, TableField(lineage=QueryModelSchema["trip_miles"])
+    ]
 
 
 # Returns an int on purpose: the run is expected to reject the unsupported type.

--- a/tests/fixtures/failing_expectation/models.py
+++ b/tests/fixtures/failing_expectation/models.py
@@ -16,25 +16,32 @@ from bauplan import (
 class QueryModelSchema(TableSchema):
     """The columns query_model selects from taxi_fhvhv."""
 
-    pickup_datetime: TimestampMicroUTC
-    trip_miles: Float64
-    trip_time: Int64
+    pickup_datetime: TimestampMicroUTC | None
+    trip_miles: Float64 | None
+    trip_time: Int64 | None
 
 
 class TripMilesPushdown(TableSchema):
     """The single column the expectation reads from query_model."""
 
-    trip_miles: Annotated[Float64, TableField(lineage=QueryModelSchema["trip_miles"])]
+    trip_miles: Annotated[
+        Float64 | None, TableField(lineage=QueryModelSchema["trip_miles"])
+    ]
 
 
 class NormalizedTripsSchema(TableSchema):
     """The trip columns normalize_data reads from query_model and passes through."""
 
-    trip_time: Annotated[Int64, TableField(lineage=QueryModelSchema["trip_time"])]
-    pickup_datetime: Annotated[
-        TimestampMicroUTC, TableField(lineage=QueryModelSchema["pickup_datetime"])
+    trip_time: Annotated[
+        Int64 | None, TableField(lineage=QueryModelSchema["trip_time"])
     ]
-    trip_miles: Annotated[Float64, TableField(lineage=QueryModelSchema["trip_miles"])]
+    pickup_datetime: Annotated[
+        TimestampMicroUTC | None,
+        TableField(lineage=QueryModelSchema["pickup_datetime"]),
+    ]
+    trip_miles: Annotated[
+        Float64 | None, TableField(lineage=QueryModelSchema["trip_miles"])
+    ]
 
 
 @bauplan.expectation()

--- a/tests/fixtures/invalid_package_pppandas/models.py
+++ b/tests/fixtures/invalid_package_pppandas/models.py
@@ -16,32 +16,39 @@ from bauplan import (
 class QueryModelSchema(TableSchema):
     """The columns query_model selects from taxi_fhvhv."""
 
-    pickup_datetime: TimestampMicroUTC
-    dropoff_datetime: TimestampMicroUTC
-    PULocationID: Int64
-    DOLocationID: Int64
-    trip_miles: Float64
-    trip_time: Int64
-    base_passenger_fare: Float64
-    tolls: Float64
-    sales_tax: Float64
-    tips: Float64
+    pickup_datetime: TimestampMicroUTC | None
+    dropoff_datetime: TimestampMicroUTC | None
+    PULocationID: Int64 | None
+    DOLocationID: Int64 | None
+    trip_miles: Float64 | None
+    trip_time: Int64 | None
+    base_passenger_fare: Float64 | None
+    tolls: Float64 | None
+    sales_tax: Float64 | None
+    tips: Float64 | None
 
 
 class TripMilesPushdown(TableSchema):
     """The single column the expectation reads from query_model."""
 
-    trip_miles: Annotated[Float64, TableField(lineage=QueryModelSchema["trip_miles"])]
+    trip_miles: Annotated[
+        Float64 | None, TableField(lineage=QueryModelSchema["trip_miles"])
+    ]
 
 
 class NormalizedTripsSchema(TableSchema):
     """The trip columns normalize_data reads from query_model and passes through."""
 
-    trip_time: Annotated[Int64, TableField(lineage=QueryModelSchema["trip_time"])]
-    pickup_datetime: Annotated[
-        TimestampMicroUTC, TableField(lineage=QueryModelSchema["pickup_datetime"])
+    trip_time: Annotated[
+        Int64 | None, TableField(lineage=QueryModelSchema["trip_time"])
     ]
-    trip_miles: Annotated[Float64, TableField(lineage=QueryModelSchema["trip_miles"])]
+    pickup_datetime: Annotated[
+        TimestampMicroUTC | None,
+        TableField(lineage=QueryModelSchema["pickup_datetime"]),
+    ]
+    trip_miles: Annotated[
+        Float64 | None, TableField(lineage=QueryModelSchema["trip_miles"])
+    ]
 
 
 @bauplan.expectation()

--- a/tests/fixtures/long_running_dag/models.py
+++ b/tests/fixtures/long_running_dag/models.py
@@ -17,26 +17,31 @@ from bauplan import (
 class QueryModelSchema(TableSchema):
     """The columns query_model selects from taxi_fhvhv."""
 
-    pickup_datetime: TimestampMicroUTC
-    dropoff_datetime: TimestampMicroUTC
-    PULocationID: Int64
-    DOLocationID: Int64
-    trip_miles: Float64
-    trip_time: Int64
-    base_passenger_fare: Float64
-    tolls: Float64
-    sales_tax: Float64
-    tips: Float64
+    pickup_datetime: TimestampMicroUTC | None
+    dropoff_datetime: TimestampMicroUTC | None
+    PULocationID: Int64 | None
+    DOLocationID: Int64 | None
+    trip_miles: Float64 | None
+    trip_time: Int64 | None
+    base_passenger_fare: Float64 | None
+    tolls: Float64 | None
+    sales_tax: Float64 | None
+    tips: Float64 | None
 
 
 class NormalizedTripsSchema(TableSchema):
     """The trip columns normalize_data reads from query_model and passes through."""
 
-    trip_time: Annotated[Int64, TableField(lineage=QueryModelSchema["trip_time"])]
-    pickup_datetime: Annotated[
-        TimestampMicroUTC, TableField(lineage=QueryModelSchema["pickup_datetime"])
+    trip_time: Annotated[
+        Int64 | None, TableField(lineage=QueryModelSchema["trip_time"])
     ]
-    trip_miles: Annotated[Float64, TableField(lineage=QueryModelSchema["trip_miles"])]
+    pickup_datetime: Annotated[
+        TimestampMicroUTC | None,
+        TableField(lineage=QueryModelSchema["pickup_datetime"]),
+    ]
+    trip_miles: Annotated[
+        Float64 | None, TableField(lineage=QueryModelSchema["trip_miles"])
+    ]
 
 
 @bauplan.model()

--- a/tests/fixtures/materialize_from_param/models.py
+++ b/tests/fixtures/materialize_from_param/models.py
@@ -16,14 +16,14 @@ from bauplan import (
 class QuerySchema(TableSchema):
     """The single column query selects from taxi_fhvhv."""
 
-    dropoff_datetime: TimestampMicroUTC
+    dropoff_datetime: TimestampMicroUTC | None
 
 
 class MagicValSchema(TableSchema):
     """A single row holding the value the run was parameterized with."""
 
     magicval_field: Annotated[
-        String, TableField(doc="The value of the magicval parameter.")
+        String | None, TableField(doc="The value of the magicval parameter.")
     ]
 
 

--- a/tests/fixtures/materialize_partitioned_by_year/models.py
+++ b/tests/fixtures/materialize_partitioned_by_year/models.py
@@ -14,8 +14,8 @@ from bauplan import (
 class DropoffsSchema(TableSchema):
     """The dropoff columns the materialized table is partitioned on."""
 
-    dropoff_datetime: TimestampMicroUTC
-    PULocationID: Int64
+    dropoff_datetime: TimestampMicroUTC | None
+    PULocationID: Int64 | None
 
 
 @bauplan.model(

--- a/tests/fixtures/missing-schema/models.py
+++ b/tests/fixtures/missing-schema/models.py
@@ -12,7 +12,7 @@ from bauplan import (
 class TestSchema(TableSchema):
     """Placeholder for a schema definition."""
 
-    trip_miles: Float64
+    trip_miles: Float64 | None
 
 
 @bauplan.model(materialization_strategy="NONE")

--- a/tests/fixtures/multi-field-schema/models.py
+++ b/tests/fixtures/multi-field-schema/models.py
@@ -20,57 +20,73 @@ class TaxiModelSchema(bauplan.TableSchema):
     """Schema demonstrating all supported field types."""
 
     pickup_datetime: Annotated[
-        TimestampMicroUTC, TableField(doc="Pickup time for the ride")
+        TimestampMicroUTC | None, TableField(doc="Pickup time for the ride")
     ]
     dropoff_datetime: Annotated[
-        TimestampMicroUTC, TableField(doc="Dropoff time for the ride")
+        TimestampMicroUTC | None, TableField(doc="Dropoff time for the ride")
     ]
-    PULocationID: Annotated[Int64, TableField(doc="Identifier for pickup location")]
-    DOLocationID: Annotated[Int64, TableField(doc="Identifier for dropoff location")]
-    trip_miles: Annotated[Float64, TableField(doc="Miles traveled for a trip")]
-    trip_time: Annotated[Int64, TableField(doc="Trip duration (in seconds) ")]
-    base_passenger_fare: Annotated[Float64, TableField(doc="Base fare for a trip")]
-    tolls: Annotated[Float64, TableField(doc="Total cost from road tolls")]
-    sales_tax: Annotated[Float64, TableField(doc="Salex tax applied on the fare")]
-    tips: Annotated[Float64, TableField(doc="Amount tendered for driver tip")]
+    PULocationID: Annotated[
+        Int64 | None, TableField(doc="Identifier for pickup location")
+    ]
+    DOLocationID: Annotated[
+        Int64 | None, TableField(doc="Identifier for dropoff location")
+    ]
+    trip_miles: Annotated[Float64 | None, TableField(doc="Miles traveled for a trip")]
+    trip_time: Annotated[Int64 | None, TableField(doc="Trip duration (in seconds) ")]
+    base_passenger_fare: Annotated[
+        Float64 | None, TableField(doc="Base fare for a trip")
+    ]
+    tolls: Annotated[Float64 | None, TableField(doc="Total cost from road tolls")]
+    sales_tax: Annotated[
+        Float64 | None, TableField(doc="Salex tax applied on the fare")
+    ]
+    tips: Annotated[Float64 | None, TableField(doc="Amount tendered for driver tip")]
 
 
 class TripsPushdown(bauplan.TableSchema):
     """Pushdown to get just basic trip information."""
 
-    PULocationID: Annotated[Int64, TableField(doc="Identifier for pickup location")]
-    DOLocationID: Annotated[Int64, TableField(doc="Identifier for dropoff location")]
-    pickup_datetime: TimestampMicroUTC
-    trip_miles: Annotated[Float64, TableField(doc="Miles traveled for a trip")]
-    trip_time: Annotated[Int64, TableField(doc="Trip duration (in seconds) ")]
+    PULocationID: Annotated[
+        Int64 | None, TableField(doc="Identifier for pickup location")
+    ]
+    DOLocationID: Annotated[
+        Int64 | None, TableField(doc="Identifier for dropoff location")
+    ]
+    pickup_datetime: TimestampMicroUTC | None
+    trip_miles: Annotated[Float64 | None, TableField(doc="Miles traveled for a trip")]
+    trip_time: Annotated[Int64 | None, TableField(doc="Trip duration (in seconds) ")]
 
 
 class LocationsPushdown(bauplan.TableSchema):
     """Pushdown to get just pickup and dropoff location identifiers."""
 
-    PULocationID: Annotated[Int64, TableField(doc="Identifier for pickup location")]
-    DOLocationID: Annotated[Int64, TableField(doc="Identifier for dropoff location")]
+    PULocationID: Annotated[
+        Int64 | None, TableField(doc="Identifier for pickup location")
+    ]
+    DOLocationID: Annotated[
+        Int64 | None, TableField(doc="Identifier for dropoff location")
+    ]
 
 
 class FullTypesSchema(bauplan.TableSchema):
     """Schema demonstrating all supported field types."""
 
-    pickup_datetime: TimestampMicroUTC
+    pickup_datetime: TimestampMicroUTC | None
     pickup_location: Annotated[
-        Int64, bauplan.TableField(doc="ID of a trip's pickup location")
+        Int64 | None, bauplan.TableField(doc="ID of a trip's pickup location")
     ]
-    dropoff_location: Int64
-    trip_miles: Float64
-    trip_time: Int64
-    is_shared_ride: Bool
-    driver_name: String
-    raw_data: Binary
+    dropoff_location: Int64 | None
+    trip_miles: Float64 | None
+    trip_time: Int64 | None
+    is_shared_ride: Bool | None
+    driver_name: String | None
+    raw_data: Binary | None
 
 
 class SecondSchema(bauplan.TableSchema):
     """A second schema for multi-model coverage."""
 
-    trip_time: Int64
+    trip_time: Int64 | None
 
 
 @bauplan.model(materialization_strategy="NONE")

--- a/tests/fixtures/multiparent/models.py
+++ b/tests/fixtures/multiparent/models.py
@@ -14,20 +14,20 @@ from bauplan import (
 class Model0Schema(TableSchema):
     """The single column model_0 selects."""
 
-    col_0: String
+    col_0: String | None
 
 
 class Model1Schema(TableSchema):
     """The single column model_1 selects."""
 
-    col_1: String
+    col_1: String | None
 
 
 class Model2Schema(TableSchema):
     """The values of col_0 and col_1, stacked into one column."""
 
     col_2: Annotated[
-        String,
+        String | None,
         TableField(doc="One row per parent: the col_0 value, then the col_1 value."),
     ]
 
@@ -35,14 +35,14 @@ class Model2Schema(TableSchema):
 class Model3Schema(TableSchema):
     """model_2 with its column renamed."""
 
-    col_3: Annotated[String, TableField(lineage=Model2Schema["col_2"])]
+    col_3: Annotated[String | None, TableField(lineage=Model2Schema["col_2"])]
 
 
 class Model4Schema(TableSchema):
     """Every value seen across all four parents, stacked into one column."""
 
     col_4: Annotated[
-        String,
+        String | None,
         TableField(
             doc="col_0, col_1, both col_2 values and both col_3 values, in order."
         ),

--- a/tests/fixtures/parallel_models/models.py
+++ b/tests/fixtures/parallel_models/models.py
@@ -15,7 +15,7 @@ from bauplan import (
 class PickupsSchema(TableSchema):
     """The single column read from taxi_fhvhv and passed down the DAG."""
 
-    pickup_datetime: TimestampMicroUTC
+    pickup_datetime: TimestampMicroUTC | None
 
 
 # @bauplan.model(materialization_strategy='REPLACE')

--- a/tests/fixtures/parameters/models.py
+++ b/tests/fixtures/parameters/models.py
@@ -17,34 +17,38 @@ from bauplan import (
 class QueryModelSchema(TableSchema):
     """The columns query_model selects from taxi_fhvhv."""
 
-    pickup_datetime: TimestampMicroUTC
-    dropoff_datetime: TimestampMicroUTC
-    PULocationID: Int64
-    DOLocationID: Int64
-    trip_miles: Float64
-    trip_time: Int64
-    base_passenger_fare: Float64
-    tolls: Float64
-    sales_tax: Float64
-    tips: Float64
+    pickup_datetime: TimestampMicroUTC | None
+    dropoff_datetime: TimestampMicroUTC | None
+    PULocationID: Int64 | None
+    DOLocationID: Int64 | None
+    trip_miles: Float64 | None
+    trip_time: Int64 | None
+    base_passenger_fare: Float64 | None
+    tolls: Float64 | None
+    sales_tax: Float64 | None
+    tips: Float64 | None
 
 
 class TripsPushdown(TableSchema):
     """The trip columns the model reads from query_model."""
 
     dropoff_datetime: Annotated[
-        TimestampMicroUTC, TableField(lineage=QueryModelSchema["dropoff_datetime"])
+        TimestampMicroUTC | None,
+        TableField(lineage=QueryModelSchema["dropoff_datetime"]),
     ]
     pickup_datetime: Annotated[
-        TimestampMicroUTC, TableField(lineage=QueryModelSchema["pickup_datetime"])
+        TimestampMicroUTC | None,
+        TableField(lineage=QueryModelSchema["pickup_datetime"]),
     ]
-    trip_miles: Annotated[Float64, TableField(lineage=QueryModelSchema["trip_miles"])]
+    trip_miles: Annotated[
+        Float64 | None, TableField(lineage=QueryModelSchema["trip_miles"])
+    ]
 
 
 class ConstantSchema(TableSchema):
     """A fixed table, returned so the model has an output at all."""
 
-    y: Annotated[Int64, TableField(doc="A constant, unrelated to the input.")]
+    y: Annotated[Int64 | None, TableField(doc="A constant, unrelated to the input.")]
 
 
 @bauplan.model(materialization_strategy="NONE")

--- a/tests/fixtures/parameters_kms_ssm/models.py
+++ b/tests/fixtures/parameters_kms_ssm/models.py
@@ -16,13 +16,13 @@ from bauplan import (
 class TripMilesPushdown(TableSchema):
     """The single column the model reads from taxi_fhvhv."""
 
-    trip_miles: Float64
+    trip_miles: Float64 | None
 
 
 class ConstantSchema(TableSchema):
     """A fixed table, returned so the model has an output at all."""
 
-    y: Annotated[Int64, TableField(doc="A constant, unrelated to the input.")]
+    y: Annotated[Int64 | None, TableField(doc="A constant, unrelated to the input.")]
 
 
 @bauplan.model(materialization_strategy="NONE")

--- a/tests/fixtures/parquet_field_ids/models.py
+++ b/tests/fixtures/parquet_field_ids/models.py
@@ -17,18 +17,20 @@ from bauplan import (
 class PickupPushdown(TableSchema):
     """The single column parent reads from taxi_fhvhv."""
 
-    pickup_datetime: TimestampMicroUTC
+    pickup_datetime: TimestampMicroUTC | None
 
 
 class SyntheticSchema(TableSchema):
     """Columns built by hand, standing in for a table that carries field ids."""
 
-    col1: Annotated[Int32, TableField(doc="Carries PARQUET:field_id 3 on the way out.")]
+    col1: Annotated[
+        Int32 | None, TableField(doc="Carries PARQUET:field_id 3 on the way out.")
+    ]
     col2: Annotated[
-        String, TableField(doc="Carries PARQUET:field_id 6 on the way out.")
+        String | None, TableField(doc="Carries PARQUET:field_id 6 on the way out.")
     ]
     col3: Annotated[
-        Float64, TableField(doc="Carries PARQUET:field_id 20 on the way out.")
+        Float64 | None, TableField(doc="Carries PARQUET:field_id 20 on the way out.")
     ]
 
 

--- a/tests/fixtures/prophet/expectations.py
+++ b/tests/fixtures/prophet/expectations.py
@@ -15,7 +15,9 @@ from bauplan.standard_expectations import expect_column_mean_greater_than
 class TripMilesPushdown(TableSchema):
     """The single column the expectation reads from query_model."""
 
-    trip_miles: Annotated[Float64, TableField(lineage="QueryModelSchema['trip_miles']")]
+    trip_miles: Annotated[
+        Float64 | None, TableField(lineage="QueryModelSchema['trip_miles']")
+    ]
 
 
 @bauplan.expectation()

--- a/tests/fixtures/prophet/models.py
+++ b/tests/fixtures/prophet/models.py
@@ -19,80 +19,91 @@ from bauplan import (
 class QueryModelSchema(TableSchema):
     """The columns query_model selects from taxi_fhvhv."""
 
-    pickup_datetime: TimestampMicroUTC
-    dropoff_datetime: TimestampMicroUTC
-    PULocationID: Int64
-    DOLocationID: Int64
-    trip_miles: Float64
-    trip_time: Int64
-    base_passenger_fare: Float64
-    tolls: Float64
-    sales_tax: Float64
-    tips: Float64
+    pickup_datetime: TimestampMicroUTC | None
+    dropoff_datetime: TimestampMicroUTC | None
+    PULocationID: Int64 | None
+    DOLocationID: Int64 | None
+    trip_miles: Float64 | None
+    trip_time: Int64 | None
+    base_passenger_fare: Float64 | None
+    tolls: Float64 | None
+    sales_tax: Float64 | None
+    tips: Float64 | None
 
 
 class TripsPushdown(TableSchema):
     """The trip columns normalize_data reads from query_model."""
 
-    trip_time: Annotated[Int64, TableField(lineage=QueryModelSchema["trip_time"])]
-    pickup_datetime: Annotated[
-        TimestampMicroUTC, TableField(lineage=QueryModelSchema["pickup_datetime"])
+    trip_time: Annotated[
+        Int64 | None, TableField(lineage=QueryModelSchema["trip_time"])
     ]
-    trip_miles: Annotated[Float64, TableField(lineage=QueryModelSchema["trip_miles"])]
+    pickup_datetime: Annotated[
+        TimestampMicroUTC | None,
+        TableField(lineage=QueryModelSchema["pickup_datetime"]),
+    ]
+    trip_miles: Annotated[
+        Float64 | None, TableField(lineage=QueryModelSchema["trip_miles"])
+    ]
 
 
 class NormalizedTripsSchema(TableSchema):
     """Trips from 2023 on with a positive distance, plus a log transform and a date."""
 
     trip_time: Annotated[
-        Int64,
+        Int64 | None,
         TableField(
             doc="Trip duration (in seconds), for trips from 2023 on.",
             lineage=TripsPushdown["trip_time"],
         ),
     ]
     pickup_datetime: Annotated[
-        TimestampNanoUTC,
+        TimestampNanoUTC | None,
         TableField(
             doc="Pickup time, at nanosecond precision after the pandas round trip.",
         ),
     ]
     trip_miles: Annotated[
-        Float64,
+        Float64 | None,
         TableField(
             doc="Miles traveled, for trips that covered more than zero of them.",
             lineage=TripsPushdown["trip_miles"],
         ),
     ]
     log_trip_miles: Annotated[
-        Float64, TableField(doc="Base 10 logarithm of trip_miles.")
+        Float64 | None, TableField(doc="Base 10 logarithm of trip_miles.")
     ]
-    ds: Annotated[Date32, TableField(doc="The pickup date, without a time of day.")]
+    ds: Annotated[
+        Date32 | None, TableField(doc="The pickup date, without a time of day.")
+    ]
 
 
 class TrainingDatePushdown(TableSchema):
     """The date column training_dataset counts trips by."""
 
-    ds: Annotated[Date32, TableField(lineage=NormalizedTripsSchema["ds"])]
+    ds: Annotated[Date32 | None, TableField(lineage=NormalizedTripsSchema["ds"])]
 
 
 class TrainingDatasetSchema(TableSchema):
     """Trips per day, the series the forecast is fit on."""
 
-    ds: Annotated[Date32, TableField(lineage=TrainingDatePushdown["ds"])]
-    y: Annotated[Int64, TableField(doc="Number of trips taken on ds.")]
+    ds: Annotated[Date32 | None, TableField(lineage=TrainingDatePushdown["ds"])]
+    y: Annotated[Int64 | None, TableField(doc="Number of trips taken on ds.")]
 
 
 class ForecastSchema(TableSchema):
     """Predicted daily trip counts, with the bounds of the prediction interval."""
 
     ds: Annotated[
-        TimestampNano,
+        TimestampNano | None,
         TableField(doc="Day being predicted; extends past the training data."),
     ]
-    yhat: Annotated[Float64, TableField(doc="Predicted number of trips on ds.")]
-    yhat_lower: Annotated[Float64, TableField(doc="Lower bound of the prediction.")]
-    yhat_upper: Annotated[Float64, TableField(doc="Upper bound of the prediction.")]
+    yhat: Annotated[Float64 | None, TableField(doc="Predicted number of trips on ds.")]
+    yhat_lower: Annotated[
+        Float64 | None, TableField(doc="Lower bound of the prediction.")
+    ]
+    yhat_upper: Annotated[
+        Float64 | None, TableField(doc="Upper bound of the prediction.")
+    ]
 
 
 @bauplan.model(materialization_strategy="NONE")

--- a/tests/fixtures/python_3_11/models.py
+++ b/tests/fixtures/python_3_11/models.py
@@ -14,7 +14,7 @@ from bauplan import (
 class LocationSchema(TableSchema):
     """The distinct pickup locations query_model selects from taxi_fhvhv."""
 
-    location_id: Int64
+    location_id: Int64 | None
 
 
 @bauplan.model(

--- a/tests/fixtures/python_3_12/models.py
+++ b/tests/fixtures/python_3_12/models.py
@@ -14,7 +14,7 @@ from bauplan import (
 class LocationSchema(TableSchema):
     """The distinct pickup locations query_model selects from taxi_fhvhv."""
 
-    location_id: Int64
+    location_id: Int64 | None
 
 
 @bauplan.model(

--- a/tests/fixtures/python_3_13/models.py
+++ b/tests/fixtures/python_3_13/models.py
@@ -14,7 +14,7 @@ from bauplan import (
 class LocationSchema(TableSchema):
     """The distinct pickup locations query_model selects from taxi_fhvhv."""
 
-    location_id: Int64
+    location_id: Int64 | None
 
 
 @bauplan.model(

--- a/tests/fixtures/schema-wrong-base/models.py
+++ b/tests/fixtures/schema-wrong-base/models.py
@@ -17,11 +17,11 @@ class CustomBase: ...
 class BadBaseSchema(CustomBase):
     """This schema has the wrong base class and should not be registered."""
 
-    trip_miles: Float64
+    trip_miles: Float64 | None
 
 
 class TaxiPushdown(TableSchema):
-    trip_miles: Float64
+    trip_miles: Float64 | None
 
 
 @bauplan.model()

--- a/tests/fixtures/sdk_expectations/models.py
+++ b/tests/fixtures/sdk_expectations/models.py
@@ -17,32 +17,39 @@ from bauplan.standard_expectations import expect_column_all_null
 class QueryModelSchema(TableSchema):
     """The columns query_model selects from taxi_fhvhv."""
 
-    pickup_datetime: TimestampMicroUTC
-    dropoff_datetime: TimestampMicroUTC
-    PULocationID: Int64
-    DOLocationID: Int64
-    trip_miles: Float64
-    trip_time: Int64
-    base_passenger_fare: Float64
-    tolls: Float64
-    sales_tax: Float64
-    tips: Float64
+    pickup_datetime: TimestampMicroUTC | None
+    dropoff_datetime: TimestampMicroUTC | None
+    PULocationID: Int64 | None
+    DOLocationID: Int64 | None
+    trip_miles: Float64 | None
+    trip_time: Int64 | None
+    base_passenger_fare: Float64 | None
+    tolls: Float64 | None
+    sales_tax: Float64 | None
+    tips: Float64 | None
 
 
 class TripMilesPushdown(TableSchema):
     """The single column the expectation reads from query_model."""
 
-    trip_miles: Annotated[Float64, TableField(lineage=QueryModelSchema["trip_miles"])]
+    trip_miles: Annotated[
+        Float64 | None, TableField(lineage=QueryModelSchema["trip_miles"])
+    ]
 
 
 class NormalizedTripsSchema(TableSchema):
     """The trip columns normalize_data reads from query_model and passes through."""
 
-    trip_time: Annotated[Int64, TableField(lineage=QueryModelSchema["trip_time"])]
-    pickup_datetime: Annotated[
-        TimestampMicroUTC, TableField(lineage=QueryModelSchema["pickup_datetime"])
+    trip_time: Annotated[
+        Int64 | None, TableField(lineage=QueryModelSchema["trip_time"])
     ]
-    trip_miles: Annotated[Float64, TableField(lineage=QueryModelSchema["trip_miles"])]
+    pickup_datetime: Annotated[
+        TimestampMicroUTC | None,
+        TableField(lineage=QueryModelSchema["pickup_datetime"]),
+    ]
+    trip_miles: Annotated[
+        Float64 | None, TableField(lineage=QueryModelSchema["trip_miles"])
+    ]
 
 
 @bauplan.expectation()

--- a/tests/fixtures/simple_taxi_dag/models.py
+++ b/tests/fixtures/simple_taxi_dag/models.py
@@ -16,26 +16,31 @@ from bauplan import (
 class QueryModelSchema(TableSchema):
     """The columns query_model selects from taxi_fhvhv."""
 
-    pickup_datetime: TimestampMicroUTC
-    dropoff_datetime: TimestampMicroUTC
-    PULocationID: Int64
-    DOLocationID: Int64
-    trip_miles: Float64
-    trip_time: Int64
-    base_passenger_fare: Float64
-    tolls: Float64
-    sales_tax: Float64
-    tips: Float64
+    pickup_datetime: TimestampMicroUTC | None
+    dropoff_datetime: TimestampMicroUTC | None
+    PULocationID: Int64 | None
+    DOLocationID: Int64 | None
+    trip_miles: Float64 | None
+    trip_time: Int64 | None
+    base_passenger_fare: Float64 | None
+    tolls: Float64 | None
+    sales_tax: Float64 | None
+    tips: Float64 | None
 
 
 class NormalizedTripsSchema(TableSchema):
     """The trip columns normalize_data reads from query_model and passes through."""
 
-    trip_time: Annotated[Int64, TableField(lineage=QueryModelSchema["trip_time"])]
-    pickup_datetime: Annotated[
-        TimestampMicroUTC, TableField(lineage=QueryModelSchema["pickup_datetime"])
+    trip_time: Annotated[
+        Int64 | None, TableField(lineage=QueryModelSchema["trip_time"])
     ]
-    trip_miles: Annotated[Float64, TableField(lineage=QueryModelSchema["trip_miles"])]
+    pickup_datetime: Annotated[
+        TimestampMicroUTC | None,
+        TableField(lineage=QueryModelSchema["pickup_datetime"]),
+    ]
+    trip_miles: Annotated[
+        Float64 | None, TableField(lineage=QueryModelSchema["trip_miles"])
+    ]
 
 
 @bauplan.model(materialization_strategy="REPLACE")

--- a/tests/fixtures/syntax-smoke/models.py
+++ b/tests/fixtures/syntax-smoke/models.py
@@ -51,48 +51,47 @@ materialize_partitions: ModelMaterializationStrategy = "OVERWRITE_PARTITIONS"
 
 # Define some schemas
 class BareTypesSchema(TableSchema):
-    bare_bool: Bool
-    bare_int: Int32
-    bare_long: Int64
-    bare_float: Float64
+    bare_bool: Bool | None
+    bare_int: Int32 | None
+    bare_long: Int64 | None
+    bare_float: Float64 | None
     # A parameterized type takes its parameters as type parameters
-    bare_decimal: Decimal128[38, 10]  # ty: ignore[invalid-type-form]
-    bare_str: String
-    bare_binary: Binary
-    bare_date32: Date32
-    bare_date64: Date64
-    bare_ts_micro: TimestampMicro
-    bare_ts_nano: TimestampNano
-    bare_ts_micro_utc: TimestampMicroUTC
-    bare_ts_nano_utc: TimestampNanoUTC
+    bare_decimal: Decimal128[38, 10] | None  # ty: ignore[invalid-type-form]
+    bare_str: String | None
+    bare_binary: Binary | None
+    bare_date32: Date32 | None
+    bare_date64: Date64 | None
+    bare_ts_micro: TimestampMicro | None
+    bare_ts_nano: TimestampNano | None
+    bare_ts_micro_utc: TimestampMicroUTC | None
+    bare_ts_nano_utc: TimestampNanoUTC | None
 
 
 class AnnotatedTypesSchema(TableSchema):
-    annotated_bool: Annotated[Bool, TableField(doc="bool docstring")]
-    annotated_int: Annotated[Int32, TableField(title="int32 doc title")]
-    annotated_long: Annotated[Int64, TableField(nullable=True)]
-    annotated_float: Annotated[Float64, TableField(nullable=False)]
+    annotated_bool: Annotated[Bool | None, TableField(doc="bool docstring")]
+    annotated_int: Annotated[Int32 | None, TableField(title="int32 doc title")]
+    annotated_long: Annotated[Int64 | None, TableField()]
+    annotated_float: Annotated[Float64, TableField()]
     annotated_decimal: Annotated[
-        Decimal128[38, 10],  # ty: ignore[invalid-type-form]
+        Decimal128[38, 10] | None,  # ty: ignore[invalid-type-form]
         TableField(
             doc="decimal docstring",
             lineage=BareTypesSchema["bare_decimal"],
         ),
     ]
-    annotated_str: Annotated[String, TableField(lineage=BareTypesSchema["bare_str"])]
+    annotated_str: Annotated[
+        String | None, TableField(lineage=BareTypesSchema["bare_str"])
+    ]
     annotated_binary: Annotated[
-        Binary, TableField(lineage='BareTypesSchema["bare_binary"]')
+        Binary | None, TableField(lineage='BareTypesSchema["bare_binary"]')
     ]
-    annotated_date32: Annotated[Date32, TableField(doc="days since epoch")]
-    annotated_date64: Annotated[
-        Date64, TableField(doc="milliseconds since epoch", nullable=False)
-    ]
+    annotated_date32: Annotated[Date32 | None, TableField(doc="days since epoch")]
+    annotated_date64: Annotated[Date64, TableField(doc="milliseconds since epoch")]
     annotated_ts_micro: Annotated[
         TimestampMicro,
         TableField(
             doc="TS micro docstring",
             title="TS micro doc title",
-            nullable=False,
             lineage=BareTypesSchema["bare_ts_micro"],
         ),
     ]
@@ -101,25 +100,22 @@ class AnnotatedTypesSchema(TableSchema):
         TableField(
             doc="TS nano docstring",
             title="TS nano doc title",
-            nullable=False,
             lineage="BareTypesSchema['bare_ts_nano']",
         ),
     ]
     annotated_ts_micro_utc: Annotated[
-        TimestampMicroUTC,
+        TimestampMicroUTC | None,
         TableField(
             doc="TS micro UTC docstring",
             title="TS micro UTC doc title",
-            nullable=True,
             lineage=BareTypesSchema["bare_ts_micro_utc"],
         ),
     ]
     annotated_ts_nano_utc: Annotated[
-        TimestampNanoUTC,
+        TimestampNanoUTC | None,
         TableField(
             doc="TS nano UTC docstring",
             title="TS nano UTC doc title",
-            nullable=True,
             lineage="BareTypesSchema['bare_ts_nano_utc']",
         ),
     ]

--- a/uv.lock
+++ b/uv.lock
@@ -538,7 +538,7 @@ dev = [
 
 [[package]]
 name = "bauplan-sdk-types"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "bauplan-sdk-types" }
 dependencies = [
     { name = "pyarrow" },


### PR DESCRIPTION
This updates examples to accommodate change from `nullable` parameter for `TableField` to python type annotation such as `... | None`.