### PR TITLE
feat(pysdk): drop the title parameter of TableField

### DIFF
--- a/bauplan-sdk-types/pyproject.toml
+++ b/bauplan-sdk-types/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "bauplan-sdk-types"
-version = "0.1.0"
+version = "0.2.0a1"
 requires-python = ">=3.11"
 readme = "README.md"
 description = "Type and decorator definitions for authoring Bauplan pipelines"

--- a/bauplan-sdk-types/src/bauplan_sdk_types/_table_fields.py
+++ b/bauplan-sdk-types/src/bauplan_sdk_types/_table_fields.py
@@ -119,13 +119,11 @@ class TableField:
     def __init__(
         self,
         doc: Optional[str] = None,
-        title: Optional[str] = None,
         lineage: Optional[FieldType | str] = None,
         nullable: Optional[bool] = None,
     ):
         """
         `doc`: Documentation for the TableField.
-        `title`: A title for the TableField and its documentation.
         `lineage`: A reference to a `TableField` to "inherit" data and metadata from.
         `nullable`: `True` if the TableField may contain `None` values (`NULL` in SQL);
                     default value is `None`, default meaning is to accept `None` values.

--- a/docs/pages/concepts/semantic_annotations.mdx
+++ b/docs/pages/concepts/semantic_annotations.mdx
@@ -87,14 +87,13 @@ tfield_double: Float64
 ### `TableField`
 
 Metadata and constraints associated with a table column. Initial support includes:
-documentation fields (`title` and `doc`), `nullable`, and explicit column `lineage`.
+a documentation field (`doc`), `nullable`, and explicit column `lineage`.
 
 ```python type:ignore
 # Float64 with metadata or constraints
 tfield_double: Annotated[
     Float64,
     TableField(
-        title='TableField: tfield_double',
         doc='An example TableField for column metadata',
         nullable=True,
         lineage="src_table['src_col_double']",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
-dependencies = ["bauplan-sdk-types~=0.1"]
+dependencies = ["bauplan-sdk-types==0.2.0a1"]
 
 [project.urls]
 Documentation = "https://docs.bauplanlabs.com/"

--- a/tests/fixtures/syntax-smoke/models.py
+++ b/tests/fixtures/syntax-smoke/models.py
@@ -69,7 +69,7 @@ class BareTypesSchema(TableSchema):
 
 class AnnotatedTypesSchema(TableSchema):
     annotated_bool: Annotated[Bool, TableField(doc="bool docstring")]
-    annotated_int: Annotated[Int32, TableField(title="int32 doc title")]
+    annotated_int: Annotated[Int32, TableField(doc="int32 docstring")]
     annotated_long: Annotated[Int64, TableField(nullable=True)]
     annotated_float: Annotated[Float64, TableField(nullable=False)]
     annotated_decimal: Annotated[
@@ -91,7 +91,6 @@ class AnnotatedTypesSchema(TableSchema):
         TimestampMicro,
         TableField(
             doc="TS micro docstring",
-            title="TS micro doc title",
             nullable=False,
             lineage=BareTypesSchema["bare_ts_micro"],
         ),
@@ -100,7 +99,6 @@ class AnnotatedTypesSchema(TableSchema):
         TimestampNano,
         TableField(
             doc="TS nano docstring",
-            title="TS nano doc title",
             nullable=False,
             lineage="BareTypesSchema['bare_ts_nano']",
         ),
@@ -109,7 +107,6 @@ class AnnotatedTypesSchema(TableSchema):
         TimestampMicroUTC,
         TableField(
             doc="TS micro UTC docstring",
-            title="TS micro UTC doc title",
             nullable=True,
             lineage=BareTypesSchema["bare_ts_micro_utc"],
         ),
@@ -118,7 +115,6 @@ class AnnotatedTypesSchema(TableSchema):
         TimestampNanoUTC,
         TableField(
             doc="TS nano UTC docstring",
-            title="TS nano UTC doc title",
             nullable=True,
             lineage="BareTypesSchema['bare_ts_nano_utc']",
         ),

--- a/uv.lock
+++ b/uv.lock
@@ -538,7 +538,7 @@ dev = [
 
 [[package]]
 name = "bauplan-sdk-types"
-version = "0.1.0"
+version = "0.2.0a1"
 source = { editable = "bauplan-sdk-types" }
 dependencies = [
     { name = "pyarrow" },


### PR DESCRIPTION
Iceberg has a single `doc` per column, so we keep a single `doc` on `TableField` to be consistent with the underlying system where the string gets stored.