### PR TITLE
chore(pysdk): relax bauplan-sdk-types pin to `~=0.2.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "bauplan-sdk-types==0.2.0",
+    "bauplan-sdk-types~=0.2.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Any 0.2.x release of `bauplan-sdk-types` is safe to pick up, so a strict `==` is not needed.