### PR TITLE
build: bump uv to 0.12 in mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,6 @@ node = "lts"
 pinact = "3.9.0"
 protoc = "31"
 rust = { version = "1.95.0", profile = "default" }
-uv = "0.10"
+uv = "0.12"
 vale = "3.14.1"
 zizmor = "1.23.1"


### PR DESCRIPTION
After `9fbcebf` the init template requires python `~=3.13.15`, but `uv` 0.10 does not know that release and cannot download it, so `cli::init::init_generates_valid_dag` fails in CI with `No interpreter found for Python >=3.13.15, <3.14`.

https://github.com/BauplanLabs/bauplan/actions/runs/34461950468/job/102821595916?pr=450

```bash
---- cli::init::init_generates_valid_dag stdout ----
Error: ruff check failed:
error: No interpreter found for Python >=3.13.15, <3.14 in managed installations or search path

hint: uv embeds available Python downloads and may require an update to install new versions. Consider retrying on a newer version of uv.


failures:
    cli::init::init_generates_valid_dag

test result: FAILED. 58 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 116.90s

error: test failed, to rerun pass `--test cli`
error: recipe `test` failed on line 26 with exit code 101
Error: Process completed with exit code 101.

```