### PR TITLE
docs: fix syntax for partitioned_by in SQL

### DIFF
--- a/docs/pages/concepts/tables.mdx
+++ b/docs/pages/concepts/tables.mdx
@@ -133,7 +133,7 @@ In SQL models, use comments:
 
 ```sql
 -- bauplan: materialization_strategy=REPLACE
--- bauplan: partitioned-by="day(pickup_datetime), PULocationID"
+-- bauplan: partitioned_by=day(pickup_datetime),PULocationID
 
 SELECT
     PULocationID,


### PR DESCRIPTION
Fix partitioned_by syntax with underscore, and remove quotes. 

Tested on 0.3.0. Originally encountered by Timo Dechau.