### PR TITLE
docs: swap out the light and dark mode buttons

### DIFF
--- a/docs/src/css/navbar.css
+++ b/docs/src/css/navbar.css
@@ -85,3 +85,14 @@
     display: block;
   }
 }
+
+/* Show the mode the toggle switches to, not the one already active. */
+html[data-theme-choice='light'] [class*='lightToggleIcon'],
+html[data-theme-choice='dark'] [class*='darkToggleIcon'] {
+  display: none;
+}
+
+html[data-theme-choice='light'] [class*='darkToggleIcon'],
+html[data-theme-choice='dark'] [class*='lightToggleIcon'] {
+  display: initial;
+}

--- a/docs/src/theme/ColorModeToggle/index.js
+++ b/docs/src/theme/ColorModeToggle/index.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import clsx from 'clsx';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import { translate } from '@docusaurus/Translate';
+import IconLightMode from '@theme/Icon/LightMode';
+import IconDarkMode from '@theme/Icon/DarkMode';
+import IconSystemColorMode from '@theme/Icon/SystemColorMode';
+import styles from './styles.module.css';
+
+function getNextColorMode(colorMode, respectPrefersColorScheme) {
+  if (!respectPrefersColorScheme) {
+    return colorMode === 'dark' ? 'light' : 'dark';
+  }
+  switch (colorMode) {
+    case null:
+      return 'light';
+    case 'light':
+      return 'dark';
+    case 'dark':
+      return null;
+    default:
+      throw new Error(`unexpected color mode ${colorMode}`);
+  }
+}
+
+function getColorModeLabel(colorMode) {
+  switch (colorMode) {
+    case null:
+      return translate({
+        message: 'system mode',
+        id: 'theme.colorToggle.ariaLabel.mode.system',
+        description: 'The name for the system color mode',
+      });
+    case 'light':
+      return translate({
+        message: 'light mode',
+        id: 'theme.colorToggle.ariaLabel.mode.light',
+        description: 'The name for the light color mode',
+      });
+    case 'dark':
+      return translate({
+        message: 'dark mode',
+        id: 'theme.colorToggle.ariaLabel.mode.dark',
+        description: 'The name for the dark color mode',
+      });
+    default:
+      throw new Error(`unexpected color mode ${colorMode}`);
+  }
+}
+
+function getColorModeAriaLabel(colorMode) {
+  return translate(
+    {
+      message: 'Switch between dark and light mode (currently {mode})',
+      id: 'theme.colorToggle.ariaLabel',
+      description: 'The ARIA label for the color mode toggle',
+    },
+    { mode: getColorModeLabel(colorMode) },
+  );
+}
+
+function NextColorModeIcon() {
+  // All 3 icons are rendered and CSS picks one, so the right icon is there
+  // before React hydrates.
+  return (
+    <>
+      <IconLightMode aria-hidden className={clsx(styles.toggleIcon, styles.lightToggleIcon)} />
+      <IconDarkMode aria-hidden className={clsx(styles.toggleIcon, styles.darkToggleIcon)} />
+      <IconSystemColorMode aria-hidden className={clsx(styles.toggleIcon, styles.systemToggleIcon)} />
+    </>
+  );
+}
+
+function ColorModeToggle({ className, buttonClassName, respectPrefersColorScheme, value, onChange }) {
+  const isBrowser = useIsBrowser();
+  const nextColorMode = getNextColorMode(value, respectPrefersColorScheme);
+  return (
+    <div className={clsx(styles.toggle, className)}>
+      <button
+        className={clsx(
+          'clean-btn',
+          styles.toggleButton,
+          !isBrowser && styles.toggleButtonDisabled,
+          buttonClassName,
+        )}
+        type="button"
+        onClick={() => onChange(nextColorMode)}
+        disabled={!isBrowser}
+        title={getColorModeLabel(nextColorMode)}
+        aria-label={getColorModeAriaLabel(value)}>
+        <NextColorModeIcon />
+      </button>
+    </div>
+  );
+}
+
+export default React.memo(ColorModeToggle);

--- a/docs/src/theme/ColorModeToggle/styles.module.css
+++ b/docs/src/theme/ColorModeToggle/styles.module.css
@@ -1,0 +1,34 @@
+.toggle {
+  width: 2rem;
+  height: 2rem;
+}
+
+.toggleButton {
+  -webkit-tap-highlight-color: transparent;
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  transition: background var(--ifm-transition-fast);
+}
+
+.toggleButton:hover {
+  background: var(--ifm-color-emphasis-200);
+}
+
+.toggleIcon {
+  display: none;
+}
+
+/* Show the mode the button switches to, not the one already active. */
+[data-theme-choice='system'] .systemToggleIcon,
+[data-theme-choice='light'] .darkToggleIcon,
+[data-theme-choice='dark'] .lightToggleIcon {
+  display: initial;
+}
+
+.toggleButtonDisabled {
+  cursor: not-allowed;
+}


### PR DESCRIPTION
Swap the theme-changing button to the one user is switching to. I.E. when user is using the light mode, the button will show up as the crescent. 