### PR TITLE
feat(pysdk)!: use a boolean cache option on query and scan

### DIFF
--- a/examples/learn/05-advanced-git-for-data/git_for_data_tour.py
+++ b/examples/learn/05-advanced-git-for-data/git_for_data_tour.py
@@ -83,7 +83,7 @@ def main(file_path: str):
     run_1 = client.run(
         project_dir="./my_project",
         ref=my_branch_name,
-        cache="off",
+        cache=False,
         parameters={"run_id": 1},
     )
     assert run_1.job_id is not None and run_1.job_status == "SUCCESS"
@@ -101,7 +101,7 @@ def main(file_path: str):
     client.run(
         project_dir="./my_project",
         ref=my_branch_name,
-        cache="off",
+        cache=False,
         parameters={"run_id": 2},
     )
     rows = client.query(run_id_query, ref=my_branch_name).to_pylist()
@@ -150,7 +150,7 @@ def main(file_path: str):
     run_5 = client.run(
         project_dir="./my_project",
         ref=my_branch_name,
-        cache="off",
+        cache=False,
         parameters={"run_id": 5},
     )
     assert run_5.job_status != "SUCCESS" and run_5.job_id is not None
@@ -226,7 +226,7 @@ def main(file_path: str):
     txn_run = client.run(
         project_dir="./my_project",
         ref=txn_branch_name,
-        cache="off",
+        cache=False,
         parameters={"run_id": 3},
     )
     assert txn_run.job_status == "SUCCESS", f"Run failed: {txn_run.job_status}"

--- a/examples/learn/08-ingestion-and-transformation-with-dagster/src/main.py
+++ b/examples/learn/08-ingestion-and-transformation-with-dagster/src/main.py
@@ -107,7 +107,7 @@ def build_ingestion_asset(table: str, dt_partition_column: str) -> dg.AssetsDefi
             project_dir=str((AUDIT_DIR / table).resolve()),
             ref=branch,
             namespace=NAMESPACE,
-            cache="off",
+            cache=False,
             strict="on",
         )
         passed = str(state.job_status).lower() == "success"
@@ -192,7 +192,7 @@ def account_activity_summary(
         project_dir=str(TRANSFORM_DIR.resolve()),
         ref=branch,
         namespace=NAMESPACE,
-        cache="off",
+        cache=False,
         strict="on",
         parameters={"start_date": start_date, "end_date": end_date},
     )
@@ -244,7 +244,7 @@ def transactions_audit(bauplan_client: BauplanResource) -> dg.AssetCheckResult:
         ref=BASE_BRANCH,
         namespace=NAMESPACE,
         dry_run=True,
-        cache="off",
+        cache=False,
         strict="on",
     )
 
@@ -311,7 +311,7 @@ def account_events_audit(bauplan_client: BauplanResource) -> dg.AssetCheckResult
         ref=BASE_BRANCH,
         namespace=NAMESPACE,
         dry_run=True,
-        cache="off",
+        cache=False,
         strict="on",
     )
 

--- a/python/bauplan/__init__.pyi
+++ b/python/bauplan/__init__.pyi
@@ -1509,7 +1509,7 @@ class Client:
         *,
         ref: "str | Ref | None" = None,
         max_rows: "int | None" = None,
-        cache: "Literal['on', 'off'] | None" = None,
+        cache: "bool" = True,
         namespace: "str | Namespace | None" = None,
         args: "dict[str, str] | None" = None,
         priority: "int | None" = None,
@@ -1542,7 +1542,7 @@ class Client:
             query: The Bauplan query to execute. Column and table names are case-sensitive.
             ref: The ref, branch name or tag name to query from.
             max_rows: The maximum number of rows to return; default: `None` (no limit).
-            cache: Whether to enable or disable caching for the query.
+            cache: Whether to enable caching for the query. Defaults to True. Set to False to disable caching.
             namespace: The Namespace to run the query in. If not set, the query will be run in the default namespace for your account.
             args: Additional arguments to pass to the query (default: None).
             priority: Optional job priority (1-10, where 10 is highest priority).
@@ -1558,7 +1558,7 @@ class Client:
         *,
         ref: "str | Ref | None" = None,
         max_rows: "int | None" = None,
-        cache: "Literal['on', 'off'] | None" = None,
+        cache: "bool" = True,
         namespace: "str | Namespace | None" = None,
         args: "dict[str, str] | None" = None,
         priority: "int | None" = None,
@@ -1584,7 +1584,7 @@ class Client:
             query: The Bauplan query to execute. Column and table names are case-sensitive.
             ref: The ref, branch name or tag name to query from.
             max_rows: The maximum number of rows to return; default: `None` (no limit).
-            cache: Whether to enable or disable caching for the query.
+            cache: Whether to enable caching for the query. Defaults to True. Set to False to disable caching.
             namespace: The Namespace to run the query in. If not set, the query will be run in the default namespace for your account.
             args: Additional arguments to pass to the query (default: None).
             client_timeout: seconds to timeout; this also cancels the remote job execution. Defaults to 1800 seconds.
@@ -1598,7 +1598,7 @@ class Client:
         *,
         ref: "str | Ref | None" = None,
         max_rows: "int | None" = None,
-        cache: "Literal['on', 'off'] | None" = None,
+        cache: "bool" = True,
         namespace: "str | Namespace | None" = None,
         args: "dict[str, str] | None" = None,
         priority: "int | None" = None,
@@ -1626,7 +1626,7 @@ class Client:
             query: The Bauplan query to execute. Column and table names are case-sensitive.
             ref: The ref, branch name or tag name to query from.
             max_rows: The maximum number of rows to return; default: `None` (no limit).
-            cache: Whether to enable or disable caching for the query.
+            cache: Whether to enable caching for the query. Defaults to True. Set to False to disable caching.
             namespace: The Namespace to run the query in. If not set, the query will be run in the default namespace for your account.
             args: Additional arguments to pass to the query (default: `None`).
             priority: Optional job priority (1-10, where 10 is highest priority).
@@ -1644,7 +1644,7 @@ class Client:
         file_format: "Literal['json', 'jsonl']" = "json",
         ref: "str | Ref | None" = None,
         max_rows: "int | None" = None,
-        cache: "Literal['on', 'off'] | None" = None,
+        cache: "bool" = True,
         namespace: "str | Namespace | None" = None,
         args: "dict[str, str] | None" = None,
         priority: "int | None" = None,
@@ -1671,7 +1671,7 @@ class Client:
             file_format: The format to write the results in; default: `json`. Allowed values are 'json' and 'jsonl'.
             ref: The ref, branch name or tag name to query from.
             max_rows: The maximum number of rows to return; default: `None` (no limit).
-            cache: Whether to enable or disable caching for the query.
+            cache: Whether to enable caching for the query. Defaults to True. Set to False to disable caching.
             namespace: The Namespace to run the query in. If not set, the query will be run in the default namespace for your account.
             args: Additional arguments to pass to the query (default: None).
             client_timeout: seconds to timeout; this also cancels the remote job execution. Defaults to 1800 seconds.
@@ -1686,7 +1686,7 @@ class Client:
         *,
         ref: "str | Ref | None" = None,
         max_rows: "int | None" = None,
-        cache: "Literal['on', 'off'] | None" = None,
+        cache: "bool" = True,
         namespace: "str | Namespace | None" = None,
         args: "dict[str, str] | None" = None,
         priority: "int | None" = None,
@@ -1712,7 +1712,7 @@ class Client:
             query: The Bauplan query to execute. Column and table names are case-sensitive.
             ref: The ref, branch name or tag name to query from.
             max_rows: The maximum number of rows to return; default: `None` (no limit).
-            cache: Whether to enable or disable caching for the query.
+            cache: Whether to enable caching for the query. Defaults to True. Set to False to disable caching.
             namespace: The Namespace to run the query in. If not set, the query will be run in the default namespace for your account.
             args: Additional arguments to pass to the query (default: None).
             client_timeout: seconds to timeout; this also cancels the remote job execution. Defaults to 1800 seconds.
@@ -1905,7 +1905,7 @@ class Client:
         columns: "list[str] | None" = None,
         filters: "str | None" = None,
         limit: "int | None" = None,
-        cache: "Literal['on', 'off'] | None" = None,
+        cache: "bool" = True,
         namespace: "str | Namespace | None" = None,
         args: "dict[str, str] | None" = None,
         priority: "int | None" = None,
@@ -1938,7 +1938,7 @@ class Client:
             columns: The columns to return (default: `None`).
             filters: The filters to apply (default: `None`).
             limit: The maximum number of rows to return (default: `None`).
-            cache: Whether to enable or disable caching for the query.
+            cache: Whether to enable caching for the query. Defaults to True. Set to False to disable caching.
             namespace: The Namespace to run the scan in. If not set, the scan will be run in the default namespace for your account.
             args: dict of arbitrary args to pass to the backend.
             priority: Optional job priority (1-10, where 10 is highest priority).

--- a/python/tests/test_import.py
+++ b/python/tests/test_import.py
@@ -50,7 +50,7 @@ def test_create_table_and_import(client: bauplan.Client, temp_branch: str):
     result = client.query(
         query='SELECT COUNT(*) FROM "my_import_table"',
         ref=temp_branch,
-        cache="off",
+        cache=False,
     )
 
     assert result.num_rows > 0
@@ -171,7 +171,7 @@ def test_plan_and_apply(client: bauplan.Client, temp_branch: str):
     result = client.query(
         query='SELECT COUNT(*) FROM "my_plan_table"',
         ref=temp_branch,
-        cache="off",
+        cache=False,
     )
 
     assert result.num_rows > 0

--- a/python/tests/test_query.py
+++ b/python/tests/test_query.py
@@ -27,7 +27,7 @@ def test_query_taxi_fhvhv(client: bauplan.Client):
             "   AND pickup_datetime < '2023-01-02T00:00:00-05:00'"
         ),
         ref="main",
-        cache="off",
+        cache=False,
     )
 
     assert len(result) == 448004
@@ -44,7 +44,7 @@ def test_parallel_query_correctness(client: bauplan.Client):
             " ORDER BY row_number, tips"
         ),
         ref="main",
-        cache="off",
+        cache=False,
         args={
             "num_endpoints": "10",
             "flight-python": "on",

--- a/src/python.rs
+++ b/src/python.rs
@@ -255,15 +255,6 @@ where
     })
 }
 
-fn optional_on_off<'a>(name: &'static str, v: Option<&'a str>) -> PyResult<Option<&'a str>> {
-    match v {
-        None | Some("on") | Some("off") => Ok(v),
-        Some(_) => Err(PyValueError::new_err(format!(
-            "{name} must be 'on' or 'off'"
-        ))),
-    }
-}
-
 #[pymodule]
 mod _internal {
     use pyo3::prelude::*;

--- a/src/python/query.rs
+++ b/src/python/query.rs
@@ -23,7 +23,6 @@ use crate::{
         detach,
         exceptions::{BauplanError, BauplanQueryError},
         namespace::NamespaceArg,
-        optional_on_off,
         refs::RefArg,
     },
 };
@@ -44,7 +43,7 @@ impl Client {
         query: &str,
         r#ref: Option<RefArg>,
         max_rows: Option<u64>,
-        cache: Option<&str>,
+        cache: bool,
         namespace: Option<&str>,
         args: HashMap<String, String>,
         priority: Option<u32>,
@@ -52,13 +51,13 @@ impl Client {
     ) -> PyResult<(Schema, impl Stream<Item = PyResult<RecordBatch>> + use<>)> {
         let timeout = self.job_timeout(client_timeout);
         let common = self.job_request_common(priority, args)?;
-        let cache = optional_on_off("cache", cache)?;
+        let cache = if cache { "on" } else { "off" };
 
         let req = commanderpb::QueryRunRequest {
             job_request_common: Some(common),
             r#ref: r#ref.map(|r| r.0),
             sql_query: query.to_owned(),
-            cache: cache.unwrap_or_default().to_owned(),
+            cache: cache.to_owned(),
             namespace: namespace.map(str::to_owned),
         };
 
@@ -182,7 +181,7 @@ impl Client {
         query: &str,
         r#ref: Option<RefArg>,
         max_rows: Option<u64>,
-        cache: Option<&str>,
+        cache: bool,
         namespace: Option<&str>,
         args: HashMap<String, String>,
         priority: Option<u32>,
@@ -262,7 +261,7 @@ impl Client {
     ///     query: The Bauplan query to execute.
     ///     ref: The ref, branch name or tag name to query from.
     ///     max_rows: The maximum number of rows to return; default: `None` (no limit).
-    ///     cache: Whether to enable or disable caching for the query.
+    ///     cache: Whether to enable caching for the query. Defaults to True. Set to False to disable caching.
     ///     namespace: The Namespace to run the query in. If not set, the query will be run in the default namespace for your account.
     ///     args: Additional arguments to pass to the query (default: None).
     ///     priority: Optional job priority (1-10, where 10 is highest priority).
@@ -274,7 +273,7 @@ impl Client {
         *,
         r#ref: "str | Ref | None" = None,
         max_rows: "int | None" = None,
-        cache: "Literal['on', 'off'] | None" = None,
+        cache: "bool" = true,
         namespace: "str | Namespace | None" = None,
         args: "dict[str, str] | None" = None,
         priority: "int | None" = None,
@@ -287,7 +286,7 @@ impl Client {
         query: &str,
         r#ref: Option<RefArg>,
         max_rows: Option<u64>,
-        cache: Option<&str>,
+        cache: bool,
         namespace: Option<NamespaceArg>,
         args: Option<HashMap<String, String>>,
         priority: Option<u32>,
@@ -336,7 +335,7 @@ impl Client {
     ///     query: The Bauplan query to execute.
     ///     ref: The ref, branch name or tag name to query from.
     ///     max_rows: The maximum number of rows to return; default: `None` (no limit).
-    ///     cache: Whether to enable or disable caching for the query.
+    ///     cache: Whether to enable caching for the query. Defaults to True. Set to False to disable caching.
     ///     namespace: The Namespace to run the query in. If not set, the query will be run in the default namespace for your account.
     ///     args: Additional arguments to pass to the query (default: `None`).
     ///     priority: Optional job priority (1-10, where 10 is highest priority).
@@ -349,7 +348,7 @@ impl Client {
         *,
         r#ref: "str | Ref | None" = None,
         max_rows: "int | None" = None,
-        cache: "Literal['on', 'off'] | None" = None,
+        cache: "bool" = true,
         namespace: "str | Namespace | None" = None,
         args: "dict[str, str] | None" = None,
         priority: "int | None" = None,
@@ -362,7 +361,7 @@ impl Client {
         query: &str,
         r#ref: Option<RefArg>,
         max_rows: Option<u64>,
-        cache: Option<&str>,
+        cache: bool,
         namespace: Option<NamespaceArg>,
         args: Option<HashMap<String, String>>,
         priority: Option<u32>,
@@ -405,7 +404,7 @@ impl Client {
     ///     query: The Bauplan query to execute.
     ///     ref: The ref, branch name or tag name to query from.
     ///     max_rows: The maximum number of rows to return; default: `None` (no limit).
-    ///     cache: Whether to enable or disable caching for the query.
+    ///     cache: Whether to enable caching for the query. Defaults to True. Set to False to disable caching.
     ///     namespace: The Namespace to run the query in. If not set, the query will be run in the default namespace for your account.
     ///     args: Additional arguments to pass to the query (default: None).
     ///     client_timeout: seconds to timeout; this also cancels the remote job execution. Defaults to 1800 seconds.
@@ -417,7 +416,7 @@ impl Client {
         *,
         r#ref: "str | Ref | None" = None,
         max_rows: "int | None" = None,
-        cache: "Literal['on', 'off'] | None" = None,
+        cache: "bool" = true,
         namespace: "str | Namespace | None" = None,
         args: "dict[str, str] | None" = None,
         priority: "int | None" = None,
@@ -431,7 +430,7 @@ impl Client {
         query: &str,
         r#ref: Option<RefArg>,
         max_rows: Option<u64>,
-        cache: Option<&str>,
+        cache: bool,
         namespace: Option<NamespaceArg>,
         args: Option<HashMap<String, String>>,
         priority: Option<u32>,
@@ -480,7 +479,7 @@ impl Client {
     ///     query: The Bauplan query to execute.
     ///     ref: The ref, branch name or tag name to query from.
     ///     max_rows: The maximum number of rows to return; default: `None` (no limit).
-    ///     cache: Whether to enable or disable caching for the query.
+    ///     cache: Whether to enable caching for the query. Defaults to True. Set to False to disable caching.
     ///     namespace: The Namespace to run the query in. If not set, the query will be run in the default namespace for your account.
     ///     args: Additional arguments to pass to the query (default: None).
     ///     client_timeout: seconds to timeout; this also cancels the remote job execution. Defaults to 1800 seconds.
@@ -492,7 +491,7 @@ impl Client {
         *,
         r#ref: "str | Ref | None" = None,
         max_rows: "int | None" = None,
-        cache: "Literal['on', 'off'] | None" = None,
+        cache: "bool" = true,
         namespace: "str | Namespace | None" = None,
         args: "dict[str, str] | None" = None,
         priority: "int | None" = None,
@@ -506,7 +505,7 @@ impl Client {
         query: &str,
         r#ref: Option<RefArg>,
         max_rows: Option<u64>,
-        cache: Option<&str>,
+        cache: bool,
         namespace: Option<NamespaceArg>,
         args: Option<HashMap<String, String>>,
         priority: Option<u32>,
@@ -556,7 +555,7 @@ impl Client {
     ///     file_format: The format to write the results in; default: `json`. Allowed values are 'json' and 'jsonl'.
     ///     ref: The ref, branch name or tag name to query from.
     ///     max_rows: The maximum number of rows to return; default: `None` (no limit).
-    ///     cache: Whether to enable or disable caching for the query.
+    ///     cache: Whether to enable caching for the query. Defaults to True. Set to False to disable caching.
     ///     namespace: The Namespace to run the query in. If not set, the query will be run in the default namespace for your account.
     ///     args: Additional arguments to pass to the query (default: None).
     ///     client_timeout: seconds to timeout; this also cancels the remote job execution. Defaults to 1800 seconds.
@@ -569,7 +568,7 @@ impl Client {
         file_format: "Literal['json', 'jsonl']" = "json",
         r#ref: "str | Ref | None" = None,
         max_rows: "int | None" = None,
-        cache: "Literal['on', 'off'] | None" = None,
+        cache: "bool" = true,
         namespace: "str | Namespace | None" = None,
         args: "dict[str, str] | None" = None,
         priority: "int | None" = None,
@@ -584,7 +583,7 @@ impl Client {
         file_format: &str,
         r#ref: Option<RefArg>,
         max_rows: Option<u64>,
-        cache: Option<&str>,
+        cache: bool,
         namespace: Option<NamespaceArg>,
         args: Option<HashMap<String, String>>,
         priority: Option<u32>,
@@ -664,7 +663,7 @@ impl Client {
     ///     columns: The columns to return (default: `None`).
     ///     filters: The filters to apply (default: `None`).
     ///     limit: The maximum number of rows to return (default: `None`).
-    ///     cache: Whether to enable or disable caching for the query.
+    ///     cache: Whether to enable caching for the query. Defaults to True. Set to False to disable caching.
     ///     namespace: The Namespace to run the scan in. If not set, the scan will be run in the default namespace for your account.
     ///     args: dict of arbitrary args to pass to the backend.
     ///     priority: Optional job priority (1-10, where 10 is highest priority).
@@ -678,7 +677,7 @@ impl Client {
         columns: "list[str] | None" = None,
         filters: "str | None" = None,
         limit: "int | None" = None,
-        cache: "Literal['on', 'off'] | None" = None,
+        cache: "bool" = true,
         namespace: "str | Namespace | None" = None,
         args: "dict[str, str] | None" = None,
         priority: "int | None" = None,
@@ -693,7 +692,7 @@ impl Client {
         columns: Option<Vec<String>>,
         filters: Option<&str>,
         limit: Option<usize>,
-        cache: Option<&str>,
+        cache: bool,
         namespace: Option<NamespaceArg>,
         args: Option<HashMap<String, String>>,
         priority: Option<u32>,


### PR DESCRIPTION
`Client.run` moved to `cache: bool` in 0.3.0-rc.2, but `query`, `scan` and `query_to_*` still wanted `cache='on'|'off'`, so `client.query(cache=False)` failed with a `ValueError`, and this inconsistency is not great from the user pov.

Now every method takes the same `bool`, defaulting to `True` like the CLI `--no-cache` flag.

Follow up of:
- #434