### PR TITLE
test: typecheck the docstring examples of bauplan-sdk-types

### DIFF
--- a/bauplan-sdk-types/src/bauplan_sdk_types/_function_types.py
+++ b/bauplan-sdk-types/src/bauplan_sdk_types/_function_types.py
@@ -97,7 +97,7 @@ def expectation() -> Callable:
                   "but is expected to not have any null values. "
                 )
             )
-        ],
+        ]
 
     @bauplan.expectation()
     @bauplan.python('3.11')

--- a/bauplan-sdk-types/src/bauplan_sdk_types/_parameters.py
+++ b/bauplan-sdk-types/src/bauplan_sdk_types/_parameters.py
@@ -7,11 +7,11 @@ from dataclasses import dataclass
 class Parameter:
     """
     Represents a parameter that can be used to "template" values passed to a model during a run or
-    query with, e.g., ``bauplan run --parameter interest_rate=2.0``.
+    query with, e.g., `bauplan run --param interest_rate=2.0`.
 
     Syntax for accessing a parameter uses the init method as an `Annotation` to
     communicate the proper behavior to the Bauplan control plane:
-        ``proj_param: Annotated[float, Parameter('interest_rate')]``
+        `proj_param: Annotated[float, Parameter('interest_rate')]`
     """
 
     param_name: str

--- a/tests/snippets.rs
+++ b/tests/snippets.rs
@@ -112,7 +112,7 @@ fn extract_md_snippets(lang: &str, src: &str, path: &Path) -> anyhow::Result<Vec
     Ok(snippets)
 }
 
-fn extract_pyi_snippets(path: &Path, src: &str, snippets: &mut Vec<Snippet>) -> anyhow::Result<()> {
+fn extract_docstring_snippets(path: &Path, src: &str, snippets: &mut Vec<Snippet>) -> anyhow::Result<()> {
     let py_lang = tree_sitter_python::LANGUAGE.into();
 
     let mut py_parser = Parser::new();
@@ -184,17 +184,20 @@ fn docstrings() -> anyhow::Result<()> {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
 
     let mut snippets = Vec::new();
-    for entry in WalkDir::new(root.join("python/bauplan"))
-        .into_iter()
-        .filter_entry(include_entry)
-    {
+
+    let entries = ["python/bauplan", "bauplan-sdk-types/src"]
+        .iter()
+        .flat_map(|p| WalkDir::new(p).into_iter().filter_entry(include_entry));
+    for entry in entries {
         let entry = entry?;
         let path = entry.path();
-        if path.extension().is_some_and(|e| e == "pyi") {
-            let rel = path.strip_prefix(root).unwrap_or(path);
-            let src = fs::read_to_string(path)?;
-            extract_pyi_snippets(rel, &src, &mut snippets)?;
+        if path.extension().is_none_or(|e| e != "pyi" && e != "py") {
+            continue;
         }
+
+        let rel = path.strip_prefix(root).unwrap_or(path);
+        let src = fs::read_to_string(path)?;
+        extract_docstring_snippets(rel, &src, &mut snippets)?;
     }
 
     typecheck_snippets(root, &snippets)


### PR DESCRIPTION
The `docstrings` test only scanned `python/bauplan/*.pyi`, so the examples in
`bauplan-sdk-types` reached the reference docs unchecked; the `expectation()` one
had a trailing comma that made it a SyntaxError.