### PR TITLE
Inna/docs 0.3.0 pass

### DIFF
--- a/docs/pages/common-scenarios/multi-stage-pipelines.mdx
+++ b/docs/pages/common-scenarios/multi-stage-pipelines.mdx
@@ -122,8 +122,7 @@ def purchase_events(
 ) -> Annotated[pyarrow.Table, PurchaseEvents]:
     import polars as pl
 
-    df = pl.from_arrow(raw)
-    assert isinstance(df, pl.DataFrame)
+    df = pl.DataFrame(raw)
 
     result = df.with_columns(
         pl.col('brand').fill_null('Unknown'),
@@ -195,11 +194,9 @@ def purchases_by_segment(
 ) -> Annotated[pyarrow.Table, SegmentedPurchases]:
     import polars as pl
 
-    purchases_df = pl.from_arrow(purchases)
-    assert isinstance(purchases_df, pl.DataFrame)
+    purchases_df = pl.DataFrame(purchases)
 
-    users_df = pl.from_arrow(users)
-    assert isinstance(users_df, pl.DataFrame)
+    users_df = pl.DataFrame(users)
 
     result = purchases_df.join(
         users_df,
@@ -258,8 +255,7 @@ def daily_segment_stats(
 ) -> Annotated[pyarrow.Table, DailySegmentStats]:
     import polars as pl
 
-    df = pl.from_arrow(data)
-    assert isinstance(df, pl.DataFrame)
+    df = pl.DataFrame(data)
 
     result = df.with_columns(
         pl.col('event_time').str.slice(0, 10).alias('date'),

--- a/docs/pages/concepts/models.mdx
+++ b/docs/pages/concepts/models.mdx
@@ -22,7 +22,11 @@ A typical Python model consists of two decorators `@bauplan.model()` and
 `@bauplan.python()` and a function.
 
 ```python
-#! from typing import Annotated
+from typing import Annotated
+
+import bauplan
+import pyarrow
+
 class SelectedInputColumns(bauplan.TableSchema):
     """Columns read from the input table."""
 
@@ -36,40 +40,46 @@ def my_model(
         data: Annotated[
             pyarrow.Table,
             bauplan.Model(
-                'input_table',
+                "input_table",
                 projection_schema=SelectedInputColumns,
                 filter="timestamp >= '2022-12-15T00:00:00-05:00'",
             )
         ],
 ) -> Annotated[pyarrow.Table, SelectedInputColumns]:
-    ...
-
-    #! output_table = pyarrow.table({})
-    return output_table
+    return data
 ```
 
 Bauplan Models are **fully declarative**, allowing for explicit column
 selection and filter pushdown. In practice, this means your code only
 requires the name of the inputs and, optionally, the desired columns and
-filters. Naming the columns and filters you need lets the planner skip
-reading the rest of the table.
+filters.
 
-For example, you don't need to specify the type of `input_table`,
-whether it's an Iceberg Table, PyArrow Table, Pandas dataframe, or
-Polars dataframe. This approach makes the code fully portable, easier to
-reproduce across environments, and simpler to maintain.
+For example, you don't need to specify whether `input_table` is an Iceberg Table, PyArrow
+Table, Pandas dataframe, or Polars dataframe. This approach makes the code fully
+portable, easier to reproduce across environments, and simpler to maintain.
 
-:::note Filters only apply to catalog inputs
+:::note Filters only apply to models from the lakehouse catalog
 
-`filter` only works on an input that reads from the catalog. Filtering an input
-that is another model in the same pipeline is not valid syntax, and the planner
-rejects it.
+`filter` only works on an input that reads from the catalog. Filtering an input that is
+another model in the same pipeline is not supported, and the planner rejects it.
 
-For example, `bauplan.Model('orders', filter='amount > 100')` is valid when
-`orders` is a catalog table, but the same filter on
-`bauplan.Model('purchases', ...)` is rejected when `purchases` is a model in the
-same pipeline. To narrow the rows `purchases` passes along, apply the filter
-inside `purchases` and return the filtered table.
+For example, `my_model` applies a filter on `timestamp` on
+`bauplan.Model('input_table')`. This is valid because `input_table` is not defined in the
+pipeline and must come from the catalog. It is not supported for a new model,
+`other_model`, to take `my_model` as an input and apply a filter to it.
+
+```python type:ignore
+@bauplan.model()
+@bauplan.python('3.11')
+def other_model(
+    data: Annotated[
+        pyarrow.Table,
+        # filters can only be applied to models from the catalog
+        bauplan.Model("my_model", filter="timestamp <= '2022-12-16'")
+    ]
+) -> Annotated[pyarrow.Table, SelectedInputColumns]:
+    return data
+```
 
 :::
 
@@ -126,11 +136,13 @@ you declare for that model alone. Declare only what the function body
 imports.
 
 ```python
-#! from typing import Annotated
+from typing import Annotated
+import bauplan
+
 class StepOutput(bauplan.TableSchema):
     """The columns each step passes along."""
 
-    ...
+    col: bauplan.Int64
 
 @bauplan.model()
 @bauplan.python('3.11', pip={'pandas': '2.2.0'})
@@ -138,9 +150,12 @@ def step_1(
     data: Annotated[pyarrow.Table, bauplan.Model('input_table')],
 ) -> Annotated[pyarrow.Table, StepOutput]:
     import pandas
+
+    df = data.to_pandas()
+
     ...
 
-    #! return pyarrow.table({})
+    return pyarrow.table(df[['col']])
 
 @bauplan.model()
 @bauplan.python('3.11', pip={'pandas': '1.5.3'})
@@ -148,9 +163,12 @@ def step_2(
     data: Annotated[pyarrow.Table, bauplan.Model('step_1')],
 ) -> Annotated[pyarrow.Table, StepOutput]:
     import pandas
+
+    df = data.to_pandas()
+
     ...
 
-    #! return pyarrow.table({})
+    return pyarrow.table(df)
 ```
 
 ## Materializing tables with models
@@ -159,16 +177,16 @@ To write the output of a model as a table into the data catalog, use the
 `materialization_strategy` parameter in the `@bauplan.model()`
 decorator. <br/> The parameter accepts four values: `REPLACE`, `APPEND`, `NONE` (default), and `OVERWRITE_PARTITIONS`.
 
-| **Strategy**                                                          | **Description**                                                                        | **Example**                                                                                                                                         |
-| --------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <CodeString>"NONE"</CodeString>                                       | Streams model output in memory as an Arrow table without persisting to object storage. | Running will not write a table.                                                                                                                     |
-| <CodeString>"REPLACE"</CodeString>                                    | Fully overwrites the table on each run.                                                | Running a pipeline twice on a model that writes 1,000 rows will result in a final table with 1,000 rows, as each run replaces the previous table.   |
-| <CodeString>"APPEND"</CodeString>                                     | Appends new rows to an existing table.                                                 | Running a pipeline twice with a model that writes 1,000 rows results in a final table with 2,000 rows, as each run adds data to the existing table. |
-| <CodeString>"OVERWRITE_PARTITIONS"</CodeString><br/><AdvancedBadge /> | Deletes rows matching `overwrite_filter`, then appends the new rows.                   | See [details below](#overwrite-partitions).                                                                                                         |
+| **Strategy**                                    | **Description**                                                                        | **Example**                                                                                                                                         |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <CodeString>"NONE"</CodeString>                 | Streams model output in memory as an Arrow table without persisting to object storage. | Running will not write a table.                                                                                                                     |
+| <CodeString>"REPLACE"</CodeString>              | Fully overwrites the table on each run.                                                | Running a pipeline twice on a model that writes 1,000 rows will result in a final table with 1,000 rows, as each run replaces the previous table.   |
+| <CodeString>"APPEND"</CodeString>               | Appends new rows to an existing table.                                                 | Running a pipeline twice with a model that writes 1,000 rows results in a final table with 2,000 rows, as each run adds data to the existing table. |
+| <CodeString>"OVERWRITE_PARTITIONS"</CodeString> | Deletes rows matching `overwrite_filter`, then appends the new rows.                   | See [details below](#overwrite-partitions).                                                                                                         |
 
 Regardless of the `materialization_strategy` parameter, running models
-with the dry run flag - `bauplan run --dry-run` - will force the
-system to run in memory (see using `--dry-run` in the tutorial).
+with the dry run flag - `bauplan run --dry-run` - will prevent data from being
+materialized into the lakehouse catalog.
 
 ### Overwrite partitions
 
@@ -192,9 +210,7 @@ class ReprocessedRows(bauplan.TableSchema):
 def my_model(
     input: Annotated[pyarrow.Table, bauplan.Model('upstream')],
 ) -> Annotated[pyarrow.Table, ReprocessedRows]:
-    ...
-
-    #! return pyarrow.table({})
+    return input.select(['year'])
 ```
 
 Requirements:
@@ -217,7 +233,7 @@ choice such as DuckDB or DataFusion.
 
 In either approach, Bauplan treats the model's output the same - as an Arrow Table - so
 downstream models don't need to know which language produced it. This also gives you
-flexibility in handly the query results: a Python model can run SQL directly in its
+flexibility in handling the query results: a Python model can run SQL directly in its
 function body, you can pass a SQL model as an input to a separate Python model, or both.
 
 <Tabs>
@@ -235,7 +251,7 @@ class CountByColOne(bauplan.TableSchema):
 
 The query lives in a `.sql` file. The optional `output_schema` header ties the query to
 that schema, the way the return annotation does in a Python model. If `output_schema` is
-not specified, the model still runs, but other models cannot use it as an input.
+not specified, then no extra type validation is asserted on the SQL results.
 
 ```sql title="my_model.sql"
 -- bauplan: output_schema=CountByColOne
@@ -249,6 +265,9 @@ Bauplan discovers `.sql` files in the project root and takes the model name from
 filename, so this query is a model named `my_model`. Downstream models read it like any
 other node, with `bauplan.Model('my_model')`.
 
+See [SQL files](/common-scenarios/sql-files) for the other header options
+and for including `.sql` files in subdirectories below the project root.
+
   </TabItem>
   <TabItem value="duckdb" label="Python with DuckDB">
 
@@ -258,8 +277,6 @@ class SelectedInputColumns(bauplan.TableSchema):
     """Columns read from the input table."""
 
     col_1: bauplan.String
-    col_2: bauplan.Int64
-    col_3: bauplan.Float64
 
 class CountByColOne(bauplan.TableSchema):
     """Row counts grouped by `col_1`."""
@@ -293,9 +310,6 @@ def my_model(
 
   </TabItem>
 </Tabs>
-
-See [SQL files](/common-scenarios/sql-files) for the other header options
-and for including `.sql` files in subdirectories below the project root.
 
 ## Developing models
 

--- a/docs/pages/concepts/models.mdx
+++ b/docs/pages/concepts/models.mdx
@@ -48,7 +48,8 @@ def my_model(
 Bauplan Models are **fully declarative**, allowing for explicit column
 selection and filter pushdown. In practice, this means your code only
 requires the name of the inputs and, optionally, the desired columns and
-filters.
+filters. Naming the columns and filters you need lets the planner skip
+reading the rest of the table.
 
 For example, you don't need to specify the type of `input_table`,
 whether it's an Iceberg Table, PyArrow Table, Pandas dataframe, or
@@ -116,6 +117,10 @@ introduce new Python packages without worrying about backward
 compatibility. In fact, you can run a pipeline where different models
 use different versions of the same packages and different versions of
 the Python interpreter.
+
+Each model builds its own environment, so every package you declare is
+installed for that model alone. Declare only what the function body
+imports.
 
 ```python
 #! from typing import Annotated
@@ -245,64 +250,9 @@ def my_model(
     return output_table
 ```
 
-## Best practices
+## Developing models
 
-1. **Input Declaration**
-
-- Specify required columns explicitly.
-- Use filter pushdown whenever feasible for efficiency.
-
-2. **Output docstrings**
-
-- Specify the shape of the output table of a model in its docstrings.
-
-  ```python
-  #! from typing import Annotated
-  class SelectedInputColumns(bauplan.TableSchema):
-      """Columns read from the input table."""
-
-      col_1: bauplan.String
-      col_2: bauplan.Int64
-      col_3: bauplan.Float64
-
-  class CountByColOne(bauplan.TableSchema):
-      """Row counts grouped by `col_1`."""
-
-      col_1: bauplan.String
-      count: bauplan.Int64
-
-  @bauplan.model()
-  @bauplan.python("3.11")
-  def my_model(
-      data: Annotated[
-          pyarrow.Table,
-          bauplan.Model(
-              "input_table",
-              projection_schema=SelectedInputColumns,
-              filter="timestamp >= '2022-12-15T00:00:00-05:00'",
-          )
-      ],
-  ) -> Annotated[pyarrow.Table, CountByColOne]:
-      """
-      This model will aggregate and count the data by Col_1.
-      The output table will look like this:
-      | Col_1 | Count  |
-      |-------|--------|
-      | A     | 100    |
-      """
-      ...
-
-      #! return pyarrow.table({})
-  ```
-
-3. **Model environment Management**
-   - Include only minimal dependencies.
-   - Pin specific dependency versions for consistency.
-
-4. **Code Organization**
-   - Group models that form a pipeline within a single file.
-   - Separate function bodies into external modules and call them within the Bauplan models. This keeps business logic code neatly separated from the DAG and environment declaration, making code refactoring easier and future-proof.
-
-5. **Testing and Development**
-   - Use the `bauplan run --dry-run` flag for quick iteration.
-   - Employ print statements for real-time terminal feedback during development.
+Print statements in a model body stream back to your terminal while the
+run is in flight, which is the quickest way to see what a function
+actually received. Pair them with `bauplan run --dry-run` to iterate
+without materializing anything.

--- a/docs/pages/concepts/models.mdx
+++ b/docs/pages/concepts/models.mdx
@@ -3,6 +3,9 @@ title: "Models"
 description: "Build Bauplan models - declarative Python or SQL functions that transform tables. Pin per-model dependencies, materialize Iceberg outputs, and embed DuckDB SQL."
 ---
 
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
 In Bauplan, **models** are the core unit of data manipulation. They are
 declarative functions written in Python or SQL that transform one or
 more input tables into a single output table. Models are designed to
@@ -118,8 +121,8 @@ compatibility. In fact, you can run a pipeline where different models
 use different versions of the same packages and different versions of
 the Python interpreter.
 
-Each model builds its own environment, so every package you declare is
-installed for that model alone. Declare only what the function body
+Each model builds its own environment, so Bauplan installs every package
+you declare for that model alone. Declare only what the function body
 imports.
 
 ```python
@@ -207,11 +210,49 @@ Requirements:
 Many transformations, especially filtering, joining, and basic
 aggregations, are easier in SQL than in Python.
 
-While Bauplan supports SQL models directly, the **recommended best
-practice today** for most use cases is to embed your SQL in a Python
-function using DuckDB.
+There are two ways to use SQL in a model. A **SQL model** lives in its own `.sql` file as
+a single, pure SQL query executed by a SQL engine of Bauplan's choice. Inside the Python
+function of a **Python model**, SQL can be executed using an embedded SQL engine of your
+choice such as DuckDB or DataFusion.
 
-```python
+In either approach, Bauplan treats the model's output the same - as an Arrow Table - so
+downstream models don't need to know which language produced it. This also gives you
+flexibility in handly the query results: a Python model can run SQL directly in its
+function body, you can pass a SQL model as an input to a separate Python model, or both.
+
+<Tabs>
+  <TabItem value="sql" label="SQL file">
+
+The schema lives in `models.py`:
+
+```python title="models.py"
+class CountByColOne(bauplan.TableSchema):
+    """Row counts grouped by `col_1`."""
+
+    col_1: bauplan.String
+    count: bauplan.Int64
+```
+
+The query lives in a `.sql` file. The optional `output_schema` header ties the query to
+that schema, the way the return annotation does in a Python model. If `output_schema` is
+not specified, the model still runs, but other models cannot use it as an input.
+
+```sql title="my_model.sql"
+-- bauplan: output_schema=CountByColOne
+SELECT col_1, COUNT(*) AS count
+FROM input_table
+WHERE timestamp >= '2022-12-15T00:00:00-05:00'
+GROUP BY col_1
+```
+
+Bauplan discovers `.sql` files in the project root and takes the model name from the
+filename, so this query is a model named `my_model`. Downstream models read it like any
+other node, with `bauplan.Model('my_model')`.
+
+  </TabItem>
+  <TabItem value="duckdb" label="Python with DuckDB">
+
+```python title="models.py"
 #! from typing import Annotated
 class SelectedInputColumns(bauplan.TableSchema):
     """Columns read from the input table."""
@@ -250,9 +291,15 @@ def my_model(
     return output_table
 ```
 
+  </TabItem>
+</Tabs>
+
+See [SQL files](/common-scenarios/sql-files) for the other header options
+and for including `.sql` files in subdirectories below the project root.
+
 ## Developing models
 
 Print statements in a model body stream back to your terminal while the
 run is in flight, which is the quickest way to see what a function
 actually received. Pair them with `bauplan run --dry-run` to iterate
-without materializing anything.
+without materializing data to the data lake.


### PR DESCRIPTION
- Updating the code in docs/pages/common-scenarios/multi-stage-pipelines.mdx.
- Adding tabs with sql and duckDB examples side by side to the models page.
- Removing a redundant example