### PR TITLE
docs: improvements and fixes for type contracts

### DIFF
--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -39,7 +39,11 @@ jobs:
           version=$(mise tool vale --json | jq -er '.active_versions[0]')
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      # Match `just lint`: only errors and warnings gate CI. Without this the
+      # action uses MinAlertLevel from .vale.ini (suggestion), and reviewdog
+      # hard-fails once a PR's diff collects 10 annotations, even at info level.
       - uses: errata-ai/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
         with:
           version: ${{ steps.vale-version.outputs.version }}
           files: '["docs/pages", "examples"]'
+          vale_flags: "--minAlertLevel=warning"

--- a/docs/pages/concepts/models.mdx
+++ b/docs/pages/concepts/models.mdx
@@ -313,7 +313,99 @@ def my_model(
 
 ## Developing models
 
-Print statements in a model body stream back to your terminal while the
-run is in flight, which is the quickest way to see what a function
-actually received. Pair them with `bauplan run --dry-run` to iterate
-without materializing data to the data lake.
+The `--preview [on | off | head | tail]` option can be specified with `bauplan run` to
+see a portion of data for each model in the pipeline:
+
+```sh type:ignore
+bauplan run --preview head -p <path-to-project>
+```
+
+In addition, print statements in a model body stream back to your terminal while the run
+is in flight, which is the quickest way to see what a function actually received. Pair
+them with `bauplan run --dry-run` to iterate without materializing data to the data lake:
+
+```sh type:ignore
+bauplan run --dry-run --preview head -p <path-to-project>
+```
+
+## Best practices
+
+1. **Model Inputs**
+
+- For each model that reads from the lakehouse catalog:
+  - Define a projection schema to avoid reading unnecessary columns.
+  - Define a filter when appropriate to reduce reading unnecessary data.
+
+2. **Semantic Layer**
+
+- In column documentation, mention:
+  - the expected data properties of a column
+    - do values fall in a range
+    - have values been filtered
+  - if a column has a numerical type with a qualitative or categorical meaning
+  - if a column will participate in a join or aggregation
+
+- In table documentation, from a `TableSchema`, mention:
+  - if the schema is a projection schema or an output schema
+  - what models the schema is associated with
+
+
+  ```python
+  from typing import Annotated
+  import bauplan
+
+  class SelectedInputColumns(bauplan.TableSchema):
+      """
+      Projection schema applied to `input_table` containing three columns.
+
+      + ----------- +  SelectedInputColumns   + -------- +
+      | input_table | ----------------------> | my_model |
+      + ----------- +     (projection)        + -------- +
+      """
+
+      col_1: Annotated[bauplan.String, bauplan.TableField(
+          doc='aggregation key in `my_model`'
+      )]
+
+  class CountByColOne(bauplan.TableSchema):
+      """
+      Output schema for `my_model` containing two columns.
+      Row counts grouped by `col_1`.
+      """
+
+      col_1: Annotated[bauplan.String, bauplan.TableField(
+          doc='aggregation column for `my_model`',
+          lineage=SelectedInputColumns["col_1"],
+      )]
+      count: Annotated[bauplan.Int64, bauplan.TableField(
+          doc='count of unique values in `col_1`'
+      )]
+
+  @bauplan.model()
+  @bauplan.python("3.11")
+  def my_model(
+      data: Annotated[
+          pyarrow.Table,
+          bauplan.Model(
+              "input_table",
+              projection_schema=SelectedInputColumns,
+              filter="timestamp >= '2022-12-15T00:00:00-05:00'",
+          )
+      ],
+  ) -> Annotated[pyarrow.Table, CountByColOne]:
+      return (
+          data.group_by("col_1")
+              .aggregate([([], "count_all")])
+              .rename_columns(["col_1", "count"])
+      )
+  ```
+
+3. **Model environment Management**
+   - Include only minimal dependencies.
+   - Pin specific dependency versions, using `==`, for consistency.
+
+4. **Code Organization**
+   - Group models that form a pipeline within a single file.
+   - Separate function bodies into external modules and call them within the Bauplan
+     models. This keeps business logic code neatly separated from the DAG and environment
+     declaration, making code refactoring easier.

--- a/docs/pages/concepts/semantic-annotations.mdx
+++ b/docs/pages/concepts/semantic-annotations.mdx
@@ -98,7 +98,10 @@ preserve the timezone they were written from.
 
 ### `TableSchema`
 
-An ordered grouping of attributes that can be associated with Bauplan models.
+An ordered grouping of attributes that is associated with Bauplan models. A `TableSchema`
+must be associated with each model output and describes the expected output schema and
+holds documentation. It may also be optionally associated with an input model to project
+an expected schema.
 
 ```python type:ignore
 from bauplan import TableSchema, Float64
@@ -115,8 +118,8 @@ class BaseResult(TableSchema):
 
 Metadata and constraints associated with a table column. Initial support includes:
 
-- column documentation
-- explicit column data flow
+- `doc`, containing documentation for the column
+- `lineage`, representing dependencies between columns (data flow)
 
 ```python type:ignore
 import bauplan
@@ -138,6 +141,36 @@ Most semantic information is defined in schema attributes and optional `TableFie
 annotations. The `TableSchema` bridges column-level metadata and constraints with models
 (annotation on the return value) and their input tables (annotations on function
 parameters).
+
+### Writing metadata to the lakehouse
+
+The metadata specified on `TableField` and `TableSchema` instances are persisted to the
+lakehouse for later access, even from external systems. Specifically, Bauplan persists:
+- A column's "nullability", meaning whether null values are accepted (optional) or not
+  accepted (required).
+- Column documentation from the `doc` parameter for a `TableField`
+- Table documentation from the python docstring of a python model if it is defined.
+  - If the python model does not have a docstring, the docstring from the output
+    `TableSchema` is used instead.
+  - Similarly, if the model is a SQL model instead of a python model, the docstring from
+    the associated `output_schema` is used for the table documentation.
+
+Column nullability is stored with the column type in a straightforward way; for an
+`Int64` type this is equivalent to:
+
+```python
+# pyarrow representation of `Int64 | None`
+pyarrow.field('name', pyarrow.int64(), nullable=True)
+```
+
+Column documentation is stored in the `doc` property of the corresponding schema field as
+shown in the Apache Iceberg spec for [JSON serialization of
+schemas](https://iceberg.apache.org/spec/#schemas).
+
+Table documentation is stored in the `comment` property of the table properties as
+described in the Apache Iceberg documentation for [informational
+properties](https://iceberg.apache.org/docs/latest/configuration/#informational-properties).
+
 
 ## Working example
 

--- a/docs/pages/integrations/warehouses-lakehouses/index.mdx
+++ b/docs/pages/integrations/warehouses-lakehouses/index.mdx
@@ -18,6 +18,10 @@ bucket with their own cloud credentials.
 
 ## Integration options
 
+:::warning Outbound connectors to pull external tables into a Bauplan pipeline from
+Snowflake or BigQuery are not yet supported by Bauplan's new pipeline DSL introduced in
+`bauplan~=0.3.0`.
+
 - **External catalog:** plug-and-play, auto-discovery, recommended whenever supported.
 - **External tables:** manual, per-table setup, fallback for engines without catalog support.
 
@@ -62,27 +66,11 @@ This approach works everywhere, but requires more operational overhead than cata
     },
     {
       type: "link",
-      href: "/integrations/warehouses-lakehouses/snowflake-outbound",
-      label: "Snowflake → Bauplan",
-      icon: snowflakeIcon,
-      description:
-        "Pull Snowflake data into a Bauplan pipeline as an Arrow table",
-    },
-    {
-      type: "link",
       href: "/integrations/warehouses-lakehouses/big-query-inbound",
       label: "Bauplan → BigQuery",
       icon: bauplanIcon,
       description:
         "Register Bauplan data as an external Iceberg table in BigQuery",
-    },
-    {
-      type: "link",
-      href: "/integrations/warehouses-lakehouses/big-query-outbound",
-      label: "BigQuery → Bauplan",
-      icon: bigqueryIcon,
-      description:
-        "Pull BigQuery data into a Bauplan pipeline as an Arrow table",
     },
     {
       type: "link",

--- a/styles/config/vocabularies/Bauplan/accept.txt
+++ b/styles/config/vocabularies/Bauplan/accept.txt
@@ -22,6 +22,7 @@ dbt
 dbt Core
 dev
 docstrings
+docstring
 ELT
 EMR
 EMR Serverless


### PR DESCRIPTION
3 major changes:
- added metadata persistence section
- improve best practices
- deprecate connectors (outbound)

Added a section for metadata persistence to semantic annotations to clarify how table and column documentation are persisted in the lakehouse from schema specifications.

This also improves the "best practices" section by mentioning the semantic layer and updating a few bullet points and the schema from the snippet

remove links to BigQuery and Snowflake connectors (outbound).