### PR TITLE
fix: always send the parameters defined in the project file

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -8,6 +8,7 @@ use bauplan::{
     grpc::{
         self,
         generated::{self as commanderpb, JobResponseCommon},
+        job::empty_parameter_value,
     },
     project::{ParameterType, ParameterValue, ProjectFile},
 };
@@ -697,6 +698,11 @@ async fn resolve_parameters(
             });
         } else if param.required {
             bail!("missing required parameter: {name:?}");
+        } else {
+            resolved.push(commanderpb::Parameter {
+                name: name.clone(),
+                value: Some(empty_parameter_value(param)),
+            });
         }
     }
 

--- a/src/grpc/job.rs
+++ b/src/grpc/job.rs
@@ -296,6 +296,34 @@ impl From<project::ParameterValue> for commanderpb::parameter::Value {
     }
 }
 
+/// Build an unset [`commanderpb::parameter::Value`] of the right type for a
+/// parameter that has no value.
+pub fn empty_parameter_value(param: &project::ParameterDefault) -> commanderpb::parameter::Value {
+    use commanderpb::parameter::Value;
+
+    match param.param_type {
+        project::ParameterType::Str => {
+            Value::StrValue(commanderpb::StrParameterValue { value: None })
+        }
+        project::ParameterType::Int => {
+            Value::IntValue(commanderpb::IntParameterValue { value: None })
+        }
+        project::ParameterType::Float => {
+            Value::FloatValue(commanderpb::FloatParameterValue { value: None })
+        }
+        project::ParameterType::Bool => {
+            Value::BoolValue(commanderpb::BoolParameterValue { value: None })
+        }
+        project::ParameterType::Secret => Value::SecretValue(commanderpb::SecretParameterValue {
+            key: param.key.clone(),
+            value: None,
+        }),
+        project::ParameterType::Vault => {
+            Value::VaultValue(commanderpb::VaultParameterValue { value: None })
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum Stdio {
     Stdout,

--- a/src/python/run.rs
+++ b/src/python/run.rs
@@ -16,7 +16,7 @@ use tracing::{error, info, trace};
 
 use super::Client;
 use super::refs::RefArg;
-use crate::grpc::{self, generated as commanderpb};
+use crate::grpc::{self, generated as commanderpb, job::empty_parameter_value};
 use crate::project::{ParameterType, ParameterValue, ProjectFile};
 use crate::python::job::JobLogEvent;
 use crate::python::namespace::NamespaceArg;
@@ -430,6 +430,11 @@ async fn resolve_job_parameters(
             return Err(PyValueError::new_err(format!(
                 "missing required parameter: {name:?}"
             )));
+        } else {
+            resolved.push(commanderpb::Parameter {
+                name: name.clone(),
+                value: Some(empty_parameter_value(param)),
+            });
         }
     }
 


### PR DESCRIPTION
Code intelligence expects every parameter of `bauplan_project.yml` in the run request, but the cli and the pysdk skip an optional one with no value and no default; the run then fails in planning with `defined but missing`.

Now the parameter is sent with an unset value, so the server decides if the model can run without it.